### PR TITLE
fix: nighttime splash text color and item text spacing

### DIFF
--- a/src/components/styles/Section.scss
+++ b/src/components/styles/Section.scss
@@ -19,13 +19,6 @@
   box-shadow: $hover-shadow;
 }
 
-@media only screen and (max-width: 600px) {
-  .item-block {
-    padding-top: $padding-vert-mobile;
-    padding-bottom: $padding-vert-mobile;
-  }
-}
-
 .section-link-text,
 .item-link-text {
   position: relative;
@@ -44,7 +37,7 @@
   content: "";
   position: absolute;
   right: 100%;
-  bottom: 0.05em;
+  bottom: -0.05em;
   left: 0;
   transition: right 0.4s cubic-bezier(0, 0.5, 0, 1);
 }
@@ -52,4 +45,19 @@
 .section-link-text:hover::after,
 .item-link:hover .item-link-text::after {
   right: 0;
+}
+
+.item-title {
+  margin-bottom: $heading-margin-bottom;
+}
+
+.item-body {
+  margin-top: 0;
+}
+
+@media only screen and (max-width: 600px) {
+  .item-block {
+    padding-top: $padding-vert-mobile;
+    padding-bottom: $padding-vert-mobile;
+  }
 }

--- a/src/components/styles/Splash.scss
+++ b/src/components/styles/Splash.scss
@@ -39,12 +39,14 @@
   background-image: $moon-bg;
 }
 
-#splash.day, #splash.day > div {
+#splash.day,
+#splash.day > div {
   background-color: map-get($colors, splashBgDay);
   color: map-get($colors, splashTextDay);
 }
 
-#splash.night, #splash.night > div {
+#splash.night,
+#splash.night > div {
   background-color: map-get($colors, splashBgNight);
   color: map-get($colors, splashTextNight);
 }

--- a/src/components/styles/Splash.scss
+++ b/src/components/styles/Splash.scss
@@ -39,12 +39,12 @@
   background-image: $moon-bg;
 }
 
-#splash.day {
+#splash.day, #splash.day > div {
   background-color: map-get($colors, splashBgDay);
   color: map-get($colors, splashTextDay);
 }
 
-#splash.night {
+#splash.night, #splash.night > div {
   background-color: map-get($colors, splashBgNight);
   color: map-get($colors, splashTextNight);
 }

--- a/src/components/styles/_variables.scss
+++ b/src/components/styles/_variables.scss
@@ -48,6 +48,7 @@ $sm-face-height: 30px;
 $splash-transition: $navbar-transition;
 
 // Item Block
+$heading-margin-bottom: 10px;
 $hover-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
 
 // Footer


### PR DESCRIPTION
* Made sure text on splash turns white at night
* Reduced spacing between `h3` and `p` in `ItemBlock`
* Slightly increased space between underline and link text on hover