### PR TITLE
fix: Minor bugfixes

### DIFF
--- a/src/components/Section/ItemBlock.tsx
+++ b/src/components/Section/ItemBlock.tsx
@@ -6,14 +6,15 @@ import '../styles/Section.scss';
 
 interface ItemBlockProps {
   data: SectionItem;
+  newTab?: boolean;
 }
 
 function ItemBlock(props: ItemBlockProps): JSX.Element {
   return (
     <a
       className={props.data.linkPath && 'item-link'}
-      target='_blank'
-      rel='noreferrer'
+      target={props.newTab ? '_blank' : undefined}
+      rel={props.newTab ? 'noreferrer' : undefined}
       href={props.data.linkPath} >
       <div className='item-block'>
         <img

--- a/src/components/Section/index.tsx
+++ b/src/components/Section/index.tsx
@@ -30,7 +30,11 @@ function Section(props: SectionProps): JSX.Element {
             columns: window.matchMedia('(max-width: 600px)').matches ? '1 auto' : `${props.data.length} auto`,
             marginBottom: 42,
           }}>
-          { props.data.map(data => <ItemBlock data={data} key={data.title} />) }
+          { props.data.map(data =>
+            <ItemBlock
+              data={data}
+              key={data.title}
+              newTab={data.linkPath != undefined && !data.linkPath.startsWith('/')} />) }
         </div>
         <a className='section-link-text' target='_blank' rel='noreferrer' href={props.linkPath} >
           {props.linkText && props.linkText.toUpperCase()}

--- a/src/components/Team/index.tsx
+++ b/src/components/Team/index.tsx
@@ -79,6 +79,7 @@ function Team(props: TeamProps): JSX.Element {
             value={year}
             placeholder="Year"
             options={yearOptions}
+            isSearchable={false}
             aria-label="Filter by Year"
           />
           <Select
@@ -89,6 +90,7 @@ function Team(props: TeamProps): JSX.Element {
             value={role}
             placeholder="Role"
             options={roleOptions}
+            isSearchable={false}
             aria-label="Filter by Role"
           />
         </div>


### PR DESCRIPTION
* Avoid opening a new tab if the card link is relative (e.g. `/team`)
* Remove ability to type into Team filter dropdown

Resolves #54, resolves #56 