### PR TITLE
feat: fetch page text from contentful

### DIFF
--- a/utils/contentful.ts
+++ b/utils/contentful.ts
@@ -22,6 +22,20 @@ export const query = `{
   }
 }`;
 
+export const pluginTextQuery = `
+  query sunshine_plugin_test($figmaIdPrefix: String) {
+  textEntryCollection(
+    where: {
+      figmaId_contains: $figmaIdPrefix
+    }
+  ) {
+    items {
+      figmaId
+      shortText
+    }
+  }
+}`;
+
 export const fetchTeam = async (): Promise<any[] | undefined> => {
   const res = await fetch(`https://graphql.contentful.com/content/v1/spaces/${process.env.SPACE_ID}/`, {
     method: 'POST',
@@ -33,4 +47,22 @@ export const fetchTeam = async (): Promise<any[] | undefined> => {
   });
   const {data} = await res.json();
   return data?.teamMembersCollection?.items ?? [];
+};
+
+export const fetchProjectTextEntries = async (figmaIdPrefix: string): Promise<any[] | undefined> => {
+  const res = await fetch(`https://graphql.contentful.com/content/v1/spaces/${process.env.SPACE_ID}/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.CONTENTFUL_ACCESS_TOKEN}`,
+    },
+    body: JSON.stringify({
+      query: pluginTextQuery,
+      variables: {
+        figmaIdPrefix,
+      },
+    }),
+  });
+  const {data} = await res.json();
+  return data?.textEntryCollection?.items ?? [];
 };

--- a/utils/figmaPlugin.ts
+++ b/utils/figmaPlugin.ts
@@ -1,0 +1,10 @@
+import { fetchProjectTextEntries } from './contentful';
+
+export const getPageTextEntries = async (projectName: string, pageName: string): Promise<any[]> => {
+  const projectPagePrefix = `${projectName}_${pageName}`;
+  return fetchProjectTextEntries(projectPagePrefix);
+};
+
+export const getTextEntry = (textEntries: any[], id: string, placeholder: string): string => {
+  return textEntries.find((item) => item?.figmaId.endsWith(`_${id}`)).shortText || placeholder;
+};

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './contentful';
 export * from './misc';
+export * from './figmaPlugin';


### PR DESCRIPTION
Added functionality to allow page text to be fetched from contentful. Rather than creating a React Component to wrap text from contentful, I've written it as a function to give us more flexibility (so that the text can be used in js expressions etc. and not limited to jsx). This is prob not the prettiest way of doing it, but I think it's the one that minimizes how many API calls we need to make to Contentful API.

Rough outline of flow:
- Get a specific page's textEntries in the page's `getStaticProps` function. 
- Pass this through props to the page
- Call a helper function that searches through the component's textEntries for a component with a specific id

Example:
```
import { GetStaticProps } from 'next';
import { getPageTextEntries, getTextEntry } from '../utils';

interface TestProps {
    textEntries: any[];
    
}

function Test(props: TestProps): JSX.Element {
    return (
        <div>
            {getTextEntry(props.textEntries, 'bitch', 'I failed')} // sorry 'bitch' was the test id i used ;-;
        </div>
    );
}

export const getStaticProps: GetStaticProps = async () => {
  const textEntries = await getPageTextEntries('Untitled', 'Page1');
  return {
    props: {textEntries},
  };
};


export default Test;
```