### PR TITLE
feat: implement "Join Us" Button on header

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -16,6 +16,7 @@ function Navbar(props: NavbarProps): JSX.Element {
 
   const navbarRef = useRef<HTMLDivElement>(null);
   const navigationRef = useRef<HTMLDivElement>(null);
+  const joinUsDividerRef = useRef<HTMLDivElement>(null);
   const logoRef = useRef<HTMLDivElement>(null);
   const sectionsRef = useRef<(HTMLElement | null)[]>([]);
 
@@ -27,28 +28,32 @@ function Navbar(props: NavbarProps): JSX.Element {
   };
 
   const toNightStyle = () => {
-    if (!navbarRef.current || !navigationRef.current || !logoRef.current)
+    if (!navbarRef.current || !navigationRef.current || !joinUsDividerRef.current || !logoRef.current)
       return;
     const navbarStyle = navbarRef.current.style;
     const navigationStyle = navigationRef.current.style;
+    const joinUsDividerStyle = joinUsDividerRef.current.style;
     const logoStyle = logoRef.current.style;
 
     navbarStyle.backgroundColor = colors.navbarBgScroll;
     navbarStyle.color = colors.navbarTextScroll;
     navigationStyle.color = colors.navbarTextScroll;
+    joinUsDividerStyle.borderColor = colors.joinUsTextScroll;
     logoStyle.filter = 'invert(100%)';
   };
 
   const toDayStyle = () => {
-    if (navbarRef.current == null || navigationRef.current == null || logoRef.current == null)
+    if (navbarRef.current == null || navigationRef.current == null || joinUsDividerRef.current == null || logoRef.current == null)
       return;
     const navbarStyle = navbarRef.current.style;
     const navigationStyle = navigationRef.current.style;
+    const joinUsDividerStyle = joinUsDividerRef.current.style;
     const logoStyle = logoRef.current.style;
 
     navbarStyle.backgroundColor = colors.splashBgDay;
     navbarStyle.color = colors.navbarText;
     navigationStyle.color = colors.navbarText;
+    joinUsDividerStyle.borderColor = colors.joinUsText;
     logoStyle.filter = 'invert(0%)';
   };
 
@@ -133,11 +138,18 @@ function Navbar(props: NavbarProps): JSX.Element {
             style={{ fontWeight: sectionScrollStates[2] ? 700 : 400 }}>
             PROJECTS
           </a>
-          <a
-            id={'join-us'}
-            href="/join">
-            JOIN US
-          </a>
+          <div id={'join-us-divider'} ref={joinUsDividerRef}></div>
+          <div id={'join-us-container'}>
+            <a
+              id={'join-us'}
+              href="/join"
+              style={{
+                backgroundColor: window.location.pathname === "/join" ? colors.joinUsBgSelected : colors.joinUsBg,
+                fontWeight: window.location.pathname === "/join" ? 700: 400
+              }}>
+              JOIN US
+            </a>
+          </div>
         </nav>
       </div>
     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -133,6 +133,9 @@ function Navbar(props: NavbarProps): JSX.Element {
             style={{ fontWeight: sectionScrollStates[2] ? 700 : 400 }}>
             PROJECTS
           </a>
+          <button>
+            JOIN US
+          </button>
         </nav>
       </div>
     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -133,9 +133,11 @@ function Navbar(props: NavbarProps): JSX.Element {
             style={{ fontWeight: sectionScrollStates[2] ? 700 : 400 }}>
             PROJECTS
           </a>
-          <button>
+          <a
+            id={'join-us'}
+            href="/join">
             JOIN US
-          </button>
+          </a>
         </nav>
       </div>
     </div>

--- a/src/components/styles/Navbar.scss
+++ b/src/components/styles/Navbar.scss
@@ -48,6 +48,28 @@
   cursor: pointer;
 }
 
+#join-us-divider {
+  position: relative;
+  top: 8px;
+  margin-left: 2.5%;
+  display: inline-block;
+  width: 0px;
+  height: 28px;
+  border: 1px solid map-get($colors, joinUsText);
+}
+
+#join-us-container {
+  display: inline-block;
+  padding-left: 2.5%;
+}
+
+#join-us {
+  padding: 6px 30px !important;
+  border-radius: 10px;
+  border: 2px solid map-get($colors, joinUsText);
+  color: map-get($colors, joinUsText);
+}
+
 @media only screen and (max-width: 600px) {
   #navbar {
     width: 100vw;

--- a/src/components/styles/_variables.scss
+++ b/src/components/styles/_variables.scss
@@ -29,6 +29,10 @@ $colors: (
   navbarBgScroll: #000,
   navbarText: #000,
   navbarTextScroll: #fff,
+  joinUsBg: #fff,
+  joinUsBgSelected: #fff973,
+  joinUsText: #000,
+  joinUsTextScroll: #fff,
   footerBg: #000,
   footerText: #fff,
 );


### PR DESCRIPTION
#114

Added a "Join Us" button on the navbar that links to the `/join` page. Styled to be consistent with the Figma, i.e.,

- The divider switches between white and black when scrolling
- The "Join Us" button becomes yellow and the font is bolded when on the `/join` page

<img width="1680" alt="Screen Shot 2023-03-13 at 7 22 27 PM" src="https://user-images.githubusercontent.com/19766504/224876725-2f6afe74-c1be-40dd-94e4-8c0a9cfa4358.png">
<img width="1680" alt="Screen Shot 2023-03-13 at 7 22 29 PM" src="https://user-images.githubusercontent.com/19766504/224876744-c2817df2-bd3d-4195-a845-cd451b0939fc.png">
<img width="1680" alt="Screen Shot 2023-03-13 at 7 22 34 PM" src="https://user-images.githubusercontent.com/19766504/224876773-f52e055e-e4ee-4320-976b-75aa4f169250.png">
