### PR TITLE
Downgrade eslint to v8 because of Next compatibility issues with esli…

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "autoprefixer": "latest",
-    "eslint": "latest",
+    "eslint": "^8.57.0",
     "eslint-config-next": "latest",
     "postcss": "latest",
     "sass": "^1.71.1",


### PR DESCRIPTION
…nt v9

Fix lint errors associated with this issue https://github.com/vercel/next.js/issues/64409
Support for eslint 9 seems to be coming in Next.js v15