### PR TITLE
Fixed project cards on home page redirecting to the wrong page 

### DIFF
--- a/src/app/(root)/HomepageContent/index.tsx
+++ b/src/app/(root)/HomepageContent/index.tsx
@@ -43,19 +43,19 @@ export default function HomepageContent() {
                     imgSrc="/card_icons/year1.svg"
                     title="2024-2025"
                     className="md:w-1/3"
-                    href="/projects/2024-2025"
+                    href="/projects/24-25"
                 />
                 <ProjectCard
                     imgSrc="/card_icons/year2.svg"
                     title="2023-2024"
                     className="md:w-1/3"
-                    href="/projects/2023-2024"
+                    href="/projects/23-24"
                 />
                 <ProjectCard
                     imgSrc="/card_icons/year3.svg"
                     title="2022-2023"
                     className="md:w-1/3"
-                    href="/projects/2022-2023"
+                    href="/projects/22-23"
                 />
             </ContentSection>
         </div>


### PR DESCRIPTION
### Changes
- Updated `href` props for all three `ProjectCard` components in `src/app/(root)/HomepageContent/index.tsx`
  - `2024-2025` → `24-25`
  - `2023-2024` → `23-24`
  - `2022-2023` → `22-23`

Issue Related: #180 