### PR TITLE
Add portal dashboard with sidebar navigation

### DIFF
--- a/src/app/(portal)/portal/components/MyTasks.tsx
+++ b/src/app/(portal)/portal/components/MyTasks.tsx
@@ -1,0 +1,85 @@
+import { Mulish } from 'next/font/google';
+import { Task } from '../types';
+
+const mulish = Mulish({ weight: ['400', '700'], subsets: ['latin'] });
+
+interface MyTasksProps {
+  tasks: Task[];
+}
+
+export default function MyTasks({ tasks }: MyTasksProps) {
+  const getPriorityColor = (priority: string) => {
+    switch (priority) {
+      case 'high':
+        return 'bg-red-100 text-red-700';
+      case 'medium':
+        return 'bg-yellow-100 text-yellow-700';
+      case 'low':
+        return 'bg-green-100 text-green-700';
+      default:
+        return 'bg-gray-100 text-gray-700';
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'in-progress':
+        return 'bg-blue-100 text-blue-700';
+      case 'completed':
+        return 'bg-green-100 text-green-700';
+      case 'todo':
+        return 'bg-gray-100 text-gray-700';
+      default:
+        return 'bg-gray-100 text-gray-700';
+    }
+  };
+
+  return (
+    <section className={`border border-black rounded-lg p-6 text-black ${mulish.className}`}>
+      <h2 className="text-xl font-bold mb-4 text-black">My Tasks</h2>
+      <div className="border border-gray-300 rounded-lg overflow-hidden">
+        <table className="w-full">
+          <thead className="bg-gray-50 border-b border-gray-200">
+            <tr>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-black">Name</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-black">Priority</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-black">Topic</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-black">Status</th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-black">Assignee</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {tasks.map((task) => (
+              <tr key={task.id} className="hover:bg-gray-50">
+                <td className="px-4 py-3 text-sm text-black">{task.name}</td>
+                <td className="px-4 py-3">
+                  <span className={`px-2 py-1 rounded text-xs font-medium ${getPriorityColor(task.priority)}`}>
+                    {task.priority}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="px-2 py-1 rounded bg-pink-100 text-pink-700 text-xs font-medium">
+                    {task.topic}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className={`px-2 py-1 rounded text-xs font-medium ${getStatusColor(task.status)}`}>
+                    {task.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center space-x-2">
+                    <div className="w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center">
+                      <span className="text-xs font-bold text-black">{task.assignee.name.charAt(0)}</span>
+                    </div>
+                    <span className="text-sm text-black">{task.assignee.name}</span>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(portal)/portal/components/PortalSidebar.tsx
+++ b/src/app/(portal)/portal/components/PortalSidebar.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Mulish } from 'next/font/google';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const mulish = Mulish({ weight: ['400', '700'], subsets: ['latin'] });
+
+interface SidebarLink {
+  name: string;
+  href: string;
+}
+
+const sidebarLinks: SidebarLink[] = [
+  { name: 'Overview', href: '/portal' },
+  { name: 'My Project', href: '/portal/projects' },
+  { name: 'Directory', href: '/portal/directory' },
+  { name: 'Profile', href: '/portal/profile' },
+];
+
+export default function PortalSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className={`sticky top-24 self-start h-[calc(100vh-6rem)] w-64 bg-white border-r border-black p-8 text-black overflow-y-auto ${mulish.className}`}>
+      <div className="mb-12">
+        <h2 className="text-lg font-bold tracking-wide text-black">Member Portal</h2>
+      </div>
+
+      <nav className="space-y-1">
+        {sidebarLinks.map((link) => {
+          const isActive = pathname === link.href;
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`block px-4 py-3 rounded-lg transition-colors text-black ${
+                isActive
+                  ? 'bg-[#85b6ff] font-bold'
+                  : 'hover:bg-gray-100'
+              }`}
+            >
+              {link.name}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/src/app/(portal)/portal/components/ProjectDescription.tsx
+++ b/src/app/(portal)/portal/components/ProjectDescription.tsx
@@ -1,0 +1,19 @@
+import { Mulish } from 'next/font/google';
+import { Project } from '../types';
+
+const mulish = Mulish({ weight: ['400', '700'], subsets: ['latin'] });
+
+interface ProjectDescriptionProps {
+  project: Project;
+}
+
+export default function ProjectDescription({ project }: ProjectDescriptionProps) {
+  return (
+    <section className={`border border-black rounded-lg p-6 text-black ${mulish.className}`}>
+      <h2 className="text-xl font-bold mb-4 text-black">Project Description</h2>
+      <div className="bg-white border border-gray-300 rounded-lg p-4">
+        <p className="text-black">{project.description}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(portal)/portal/components/ProjectLeads.tsx
+++ b/src/app/(portal)/portal/components/ProjectLeads.tsx
@@ -1,0 +1,29 @@
+import { Mulish } from 'next/font/google';
+import { Member } from '../types';
+
+const mulish = Mulish({ weight: ['400', '700'], subsets: ['latin'] });
+
+interface ProjectLeadsProps {
+  leads: Member[];
+}
+
+export default function ProjectLeads({ leads }: ProjectLeadsProps) {
+  return (
+    <section className={`border border-black rounded-lg p-6 text-black ${mulish.className}`}>
+      <h2 className="text-xl font-bold mb-4 text-black">Project Leads</h2>
+      <div className="space-y-3">
+        {leads.map((lead) => (
+          <div key={lead.id} className="flex items-center space-x-3">
+            <div className="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center">
+              <span className="text-sm font-bold text-black">{lead.name.charAt(0)}</span>
+            </div>
+            <div>
+              <p className="font-semibold text-black">{lead.name}</p>
+              <p className="text-sm text-black">{lead.role}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/(portal)/portal/components/QuickLinks.tsx
+++ b/src/app/(portal)/portal/components/QuickLinks.tsx
@@ -1,0 +1,32 @@
+import { Mulish } from 'next/font/google';
+import { QuickLink } from '../types';
+
+const mulish = Mulish({ weight: ['400', '700'], subsets: ['latin'] });
+
+interface QuickLinksProps {
+  links: QuickLink[];
+}
+
+export default function QuickLinks({ links }: QuickLinksProps) {
+  return (
+    <section className={`border border-black rounded-lg p-6 text-black ${mulish.className}`}>
+      <h2 className="text-xl font-bold mb-4 text-black">Quick Links</h2>
+      <div className="flex space-x-4 justify-center">
+        {links.map((link) => (
+          <a
+            key={link.name}
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex flex-col items-center p-4 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <div className="w-16 h-16 bg-white border-2 border-black rounded-lg flex items-center justify-center mb-2">
+              <span className="text-2xl font-bold text-black">{link.name.charAt(0)}</span>
+            </div>
+            <span className="text-sm text-black">{link.name}</span>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/(portal)/portal/components/RecentActivity.tsx
+++ b/src/app/(portal)/portal/components/RecentActivity.tsx
@@ -1,0 +1,34 @@
+import { Mulish } from 'next/font/google';
+import { Activity } from '../types';
+
+const mulish = Mulish({ weight: ['400', '700'], subsets: ['latin'] });
+
+interface RecentActivityProps {
+  activities: Activity[];
+}
+
+export default function RecentActivity({ activities }: RecentActivityProps) {
+  return (
+    <section className={`border border-black rounded-lg p-6 text-black ${mulish.className}`}>
+      <h2 className="text-xl font-bold mb-4 text-black">Recent Activity</h2>
+      <div className="space-y-4">
+        {activities.map((activity) => (
+          <div key={activity.id} className="flex items-start space-x-3 relative">
+            <div className="flex-shrink-0 w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center text-xs font-bold text-black">
+              {activity.actorName.charAt(0)}
+            </div>
+            <div className="flex-1">
+              <p className="text-sm text-black">
+                <span className="font-semibold text-black">{activity.actorName}</span>{' '}
+                {activity.description}
+                {activity.relatedTask && (
+                  <span className="font-semibold text-black"> {activity.relatedTask}</span>
+                )}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/(portal)/portal/directory/page.tsx
+++ b/src/app/(portal)/portal/directory/page.tsx
@@ -5,7 +5,7 @@ import ProjectsDirectory from "@/components/portal/directory/ProjectsDirectory";
 export default function PortalDirectory() {
     return (
         <div className="p-8 text-black">
-                <ProjectsDirectory />
+            <ProjectsDirectory />
         </div>
     );
 }

--- a/src/app/(portal)/portal/layout.tsx
+++ b/src/app/(portal)/portal/layout.tsx
@@ -1,7 +1,8 @@
-// Portal-specific layout with sidebar/navigation
+// Portal-specific layout with sidebar navigation
 // This layout applies to all pages under /portal/*
 
-import PortalNavbar from '@/components/PortalNavbar';
+import Navbar from '@/components/Navbar';
+import PortalSidebar from './components/PortalSidebar';
 
 export default function PortalPageLayout({
     children,
@@ -9,9 +10,16 @@ export default function PortalPageLayout({
     children: React.ReactNode;
 }) {
     return (
-        <div className="min-h-screen">
-            <PortalNavbar />
-            <main className="pt-24">{children}</main>
-        </div>
+        <>
+            <Navbar />
+            <div className="flex min-h-screen bg-white pt-24">
+                <PortalSidebar />
+                <main className="flex-1 p-8">
+                    <div className="max-w-7xl mx-auto">
+                        {children}
+                    </div>
+                </main>
+            </div>
+        </>
     );
 }

--- a/src/app/(portal)/portal/page.tsx
+++ b/src/app/(portal)/portal/page.tsx
@@ -1,10 +1,107 @@
-// Dashboard/Home page for the membership portal
-// Route: /portal
+'use client';
+
+import { Mulish } from 'next/font/google';
+import ProjectDescription from './components/ProjectDescription';
+import ProjectLeads from './components/ProjectLeads';
+import MyTasks from './components/MyTasks';
+import RecentActivity from './components/RecentActivity';
+import QuickLinks from './components/QuickLinks';
+import { Project, Task, Activity, QuickLink } from './types';
+
+const mulish = Mulish({ weight: ['400', '700'], subsets: ['latin'] });
+
+// Mock data for development - replace with real data fetching later
+const mockProject: Project = {
+  id: '1',
+  name: 'Project Alpha',
+  description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  leads: [
+    {
+      id: '1',
+      name: 'John Doe',
+      email: 'john.doe@ucla.edu',
+      role: 'Project Lead',
+    },
+  ],
+  members: [],
+  status: 'active',
+  createdAt: new Date(),
+};
+
+const mockTasks: Task[] = [
+  {
+    id: '67',
+    name: 'Complete initial wireframes',
+    priority: 'high',
+    topic: 'Design',
+    status: 'in-progress',
+    assignee: {
+      id: '1',
+      name: 'Jane Smith',
+      email: 'jane@ucla.edu',
+      role: 'Member',
+    },
+    projectId: '1',
+  },
+];
+
+const mockActivities: Activity[] = [
+  {
+    id: '1',
+    type: 'task_completed',
+    description: 'completed',
+    actorName: 'John Doe',
+    relatedTask: 'Setup repository',
+    timestamp: new Date(),
+  },
+  {
+    id: '2',
+    type: 'task_added',
+    description: 'has been added',
+    actorName: 'Task: Review designs',
+    timestamp: new Date(),
+  },
+  {
+    id: '3',
+    type: 'member_added',
+    description: 'made as project lead',
+    actorName: 'Jane Smith',
+    timestamp: new Date(),
+  },
+  {
+    id: '4',
+    type: 'project_created',
+    description: '',
+    actorName: 'Project Created',
+    timestamp: new Date(),
+  },
+];
+
+const mockQuickLinks: QuickLink[] = [
+  { name: 'GitHub', url: 'https://github.com', icon: '' },
+  { name: 'Figma', url: 'https://figma.com', icon: '' },
+  { name: 'Notion', url: 'https://notion.so', icon: '' },
+];
 
 export default function PortalDashboard() {
-    return (
-        <div className="p-8 text-black">
-            <h1 className="text-3xl font-bold mb-4">Portal Dashboard</h1>
+  return (
+    <div className={mulish.className}>
+      <h1 className="text-3xl font-bold mb-8 text-black">My Project</h1>
+
+      <div className="grid grid-cols-3 gap-6">
+        {/* Left column - Project info and tasks */}
+        <div className="col-span-2 space-y-6">
+          <ProjectDescription project={mockProject} />
+          <ProjectLeads leads={mockProject.leads} />
+          <MyTasks tasks={mockTasks} />
         </div>
-    );
+
+        {/* Right column - Activity and quick links */}
+        <div className="space-y-6">
+          <RecentActivity activities={mockActivities} />
+          <QuickLinks links={mockQuickLinks} />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/app/(portal)/portal/types.ts
+++ b/src/app/(portal)/portal/types.ts
@@ -1,0 +1,64 @@
+// Shared TypeScript interfaces for the membership portal
+
+export interface Member {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  avatarUrl?: string;
+  projectId?: string;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  description: string;
+  leads: Member[];
+  members: Member[];
+  status: 'active' | 'completed' | 'on-hold';
+  createdAt: Date;
+}
+
+export interface Task {
+  id: string;
+  name: string;
+  priority: 'high' | 'medium' | 'low';
+  topic: string;
+  status: 'in-progress' | 'completed' | 'todo';
+  assignee: Member;
+  projectId: string;
+}
+
+export interface Activity {
+  id: string;
+  type: 'task_completed' | 'task_added' | 'member_added' | 'project_created';
+  description: string;
+  actorName: string;
+  timestamp: Date;
+  relatedTask?: string;
+}
+
+export interface Announcement {
+  id: string;
+  title: string;
+  content: string;
+  author: Member;
+  createdAt: Date;
+  priority: 'urgent' | 'normal' | 'info';
+}
+
+export interface Event {
+  id: string;
+  title: string;
+  description: string;
+  startTime: Date;
+  endTime: Date;
+  location: string;
+  rsvpStatus?: 'attending' | 'maybe' | 'not-attending';
+}
+
+export interface QuickLink {
+  name: string;
+  url: string;
+  icon: string;
+}

--- a/src/components/portal/directory/ProjectsDirectory.css
+++ b/src/components/portal/directory/ProjectsDirectory.css
@@ -1,14 +1,5 @@
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
-
-body {
-    font-family: Arial, sans-serif;
-    background-color: #f5f5f5;
-    padding: 20px;
-}
+/* Removed global CSS reset that was affecting other pages */
+/* Use scoped styles instead */
 
 .container {
     max-width: 1200px;


### PR DESCRIPTION
Built modular dashboard page based on MJ's Figma and design team's Figma with reusable components and sidebar navigation.

Changes:
- Dashboard page with project info, tasks, activity feed, and quick links
- Sidebar navigation component
- TypeScript interfaces for portal data types
- Integrated main site navbar
- Fixed CSS conflicts