### PR TITLE
Portal login error fix

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -22,19 +22,30 @@ export default function LoginPage() {
     setIsLoading(true);
     setError(null);
 
-    const supabase = createClient();
-    
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
+    try {
+      const supabase = createClient();
+      
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
 
-    if (error) {
-      setError(error.message);
-      setIsLoading(false);
-    } else {
-      // Redirect to portal on successful login
+      if (error) {
+        setError(error.message);
+        return;
+      }
+
+      if (!data.session) {
+        setError("Failed to create session. Please try again.");
+        return;
+      }
+
       router.push("/portal");
+    } catch (err) {
+      console.error("Login error:", err);
+      setError("An unexpected error occurred. Please try again.");
+    } finally {
+      setIsLoading(false);
     }
   };
 

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,55 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import type { NextRequest, NextResponse } from 'next/server'
+
+export async function createClient() {
+  const cookieStore = await cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            )
+          } catch {
+            // The `setAll` method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+          }
+        },
+      },
+    }
+  )
+}
+
+export function createMiddlewareClient(
+  request: NextRequest,
+  response: NextResponse
+) {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          )
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options)
+          )
+        },
+      },
+    }
+  )
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,11 +6,6 @@ export async function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl;
     const response = NextResponse.next();
 
-    // Redirect /portal to /login
-    if (pathname === '/portal') {
-        return NextResponse.redirect(new URL('/login', request.url));
-    }
-
     // Protect all /portal routes
     if (pathname.startsWith('/portal')) {
         try {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { supabase } from '@/lib/supabase/client';
+import { createMiddlewareClient } from '@/lib/supabase/server';
 
 export async function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,10 @@
-// Middleware for route protection
-
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { createMiddlewareClient } from '@/lib/supabase/server';
 
 export async function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl;
+    const response = NextResponse.next();
 
     // Redirect /portal to /login
     if (pathname === '/portal') {
@@ -14,24 +13,21 @@ export async function middleware(request: NextRequest) {
 
     // Protect all /portal routes
     if (pathname.startsWith('/portal')) {
-        const token = request.cookies.get('sb-access-token')?.value ||
-                     request.cookies.get('supabase-auth-token')?.value;
-
-        if (!token) {
-            return NextResponse.redirect(new URL('/login', request.url));
-        }
-
         try {
-            const { data: { user }, error } = await supabase.auth.getUser(token);
+            const supabase = createMiddlewareClient(request, response);
+            
+            const { data: { user }, error } = await supabase.auth.getUser();
+            
             if (error || !user) {
                 return NextResponse.redirect(new URL('/login', request.url));
             }
-        } catch {
+        } catch (error) {
+            console.error('Middleware auth error:', error);
             return NextResponse.redirect(new URL('/login', request.url));
         }
     }
 
-    return NextResponse.next();
+    return response;
 }
 
 export const config = {


### PR DESCRIPTION
I fixed the error/bug we had when trying to log in the portal, it would just hang on "logging in..." and never actually log in. It would work on Netlify but not on localhost.

## Problems Found 
1. Middleware was using `createBrowserClient` in Edge Runtime
   - `createBrowserClient` from `@supabase/ssr` is client-side only
   - Edge Runtime (Netlify) requires server-side client
   - Located in `src/middleware.ts:5`
2. The cookies were being properly handled and had hardcoded cookie names that weren't used by supabase
   - Middleware couldn't read auth cookies
   -  Supabase uses `sb-<project-ref>-auth-token` pattern
3. Not as important, but the login page loading state never reset so the user would be stuck in "logging in..."

## Changes Made
- Created ([src/lib/supabase/server.ts](cci:7://file:///Users/mj/Desktop/UCLA/Creative%20Labs/sunshine/src/lib/supabase/server.ts:0:0-0:0)) that uses `createServerClient` and handled cookies automatically.
- Fixed Middleware to use Server Client. This will work in Netlify Edge Runtime
- Fixed Login Page Error handling so loading states always reset using `try/catch/finally` block
