### PR TITLE
feat: events/announcements creation with visibility permissions

### DIFF
--- a/src/components/portal/dashboard/AnnouncementsSection.tsx
+++ b/src/components/portal/dashboard/AnnouncementsSection.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { getAllAnnouncements } from "@/lib/supabase/eventsService";
-import { ProjectAnnouncement } from "@/types/events";
+import { useEffect, useState, useCallback } from "react";
+import { getAllAnnouncements, createAnnouncement } from "@/lib/supabase/eventsService";
+import { ProjectAnnouncement, CreateAnnouncementInput } from "@/types/events";
 import ProjectAnnouncementCard from "@/components/portal/ProjectAnnouncementCard";
+import { DashboardAnnouncementModal } from "./DashboardAnnouncementModal";
+import { supabase } from "@/lib/supabase/client";
 
 function useMountAnimation(delay: number) {
   const [mounted, setMounted] = useState(false);
@@ -22,25 +24,99 @@ export default function AnnouncementsSection() {
 
   const [announcements, setAnnouncements] = useState<ProjectAnnouncement[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [canPost, setCanPost] = useState(false);
+  const [userProjects, setUserProjects] = useState<{ id: string; projectName: string; isLead: boolean }[]>([]);
+  const [isDirectorOrPresident, setIsDirectorOrPresident] = useState(false);
+
+  const fetchAnnouncements = useCallback(async () => {
+    setLoading(true);
+    const data = await getAllAnnouncements(6);
+    setAnnouncements(data);
+    setLoading(false);
+  }, []);
 
   useEffect(() => {
-    async function fetchAnnouncements() {
-      setLoading(true);
-      const data = await getAllAnnouncements(6); // Limit to 6 announcements
-      setAnnouncements(data);
-      setLoading(false);
+    fetchAnnouncements();
+  }, [fetchAnnouncements]);
+
+  // Check if user can post (is a project lead, director, or president)
+  useEffect(() => {
+    async function checkPermissions() {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+
+      // Check if user is a director or president (internal RBAC)
+      const { data: internalRoles } = await supabase
+        .from('user_context_roles')
+        .select('roles!inner(name)')
+        .eq('user_id', user.id);
+
+      const roleNames = (internalRoles || []).map(
+        (r) => ((r.roles as unknown as { name: string })?.name)
+      );
+      const isDirectorOrPresident = roleNames.some(
+        (name) => name === 'director' || name === 'president'
+      );
+
+      // Check which projects the user leads
+      const { data: memberships } = await supabase
+        .from('project_members')
+        .select('project_id, rbac_role_id, roles!inner(name), projects!inner(id, "projectName")')
+        .eq('user_id', user.id);
+
+      const projects = (memberships || []).map((m) => {
+        const role = (m.roles as unknown as { name: string })?.name;
+        const proj = m.projects as unknown as { id: string; projectName: string };
+        return {
+          id: proj?.id,
+          projectName: proj?.projectName,
+          isLead: role === 'project lead',
+        };
+      }).filter((p) => p.id);
+
+      const leadsAnyProject = projects.some((p) => p.isLead);
+
+      setUserProjects(projects.filter((p) => p.isLead));
+      setIsDirectorOrPresident(isDirectorOrPresident);
+      setCanPost(isDirectorOrPresident || leadsAnyProject);
     }
 
-    fetchAnnouncements();
+    checkPermissions();
   }, []);
+
+  const handleCreateAnnouncement = async (input: CreateAnnouncementInput) => {
+    setIsSubmitting(true);
+    try {
+      await createAnnouncement(input);
+      await fetchAnnouncements();
+      setShowModal(false);
+    } catch (err) {
+      console.error('Failed to create announcement:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <section
       className={`transform transition-all duration-300 ease-out ${enterClasses}`}
     >
-      <h2 className="text-xs font-semibold tracking-wide text-black/50 uppercase mb-4">
-        Announcements
-      </h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xs font-semibold tracking-wide text-black/50 uppercase">
+          Announcements
+        </h2>
+        {canPost && (
+          <button
+            onClick={() => setShowModal(true)}
+            className="flex items-center gap-1.5 rounded-lg bg-[#3F86FF] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#346edd] transition-colors"
+          >
+            <span className="text-base leading-none">+</span>
+            <span>New Announcement</span>
+          </button>
+        )}
+      </div>
       <div className="rounded-2xl border border-[#D4D7E5] bg-white p-6 shadow-sm">
         {loading ? (
           <div className="text-center text-black/60 py-8">
@@ -62,6 +138,15 @@ export default function AnnouncementsSection() {
           </div>
         )}
       </div>
+
+      <DashboardAnnouncementModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        onSubmit={handleCreateAnnouncement}
+        userProjects={userProjects}
+        isDirectorOrPresident={isDirectorOrPresident}
+        isSubmitting={isSubmitting}
+      />
     </section>
   );
 }

--- a/src/components/portal/dashboard/DashboardAnnouncementModal.tsx
+++ b/src/components/portal/dashboard/DashboardAnnouncementModal.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { CreateAnnouncementInput, AnnouncementVisibility, BoardTeam } from '@/types/events';
+
+interface DashboardAnnouncementModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (input: CreateAnnouncementInput) => Promise<void>;
+  userProjects: { id: string; projectName: string; isLead: boolean }[];
+  isDirectorOrPresident: boolean;
+  isSubmitting?: boolean;
+}
+
+const ANNOUNCEMENT_TYPES = [
+  { value: 'general', label: 'General' },
+  { value: 'update', label: 'Update' },
+  { value: 'milestone', label: 'Milestone' },
+  { value: 'recruitment', label: 'Recruitment' },
+  { value: 'launch', label: 'Launch' },
+];
+
+const PRIORITY_OPTIONS = [
+  { value: 'low', label: 'Low' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'high', label: 'High' },
+  { value: 'urgent', label: 'Urgent' },
+];
+
+const BOARD_TEAMS: { value: BoardTeam; label: string }[] = [
+  { value: 'tech', label: 'Tech' },
+  { value: 'finance', label: 'Finance' },
+  { value: 'marketing', label: 'Marketing' },
+  { value: 'design', label: 'Design' },
+];
+
+export function DashboardAnnouncementModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  userProjects,
+  isDirectorOrPresident,
+  isSubmitting = false,
+}: DashboardAnnouncementModalProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [announcementType, setAnnouncementType] = useState('general');
+  const [priority, setPriority] = useState('normal');
+  const [visibility, setVisibility] = useState<AnnouncementVisibility>('project');
+  const [targetTeam, setTargetTeam] = useState<BoardTeam | ''>('');
+  const [selectedProjectId, setSelectedProjectId] = useState(userProjects[0]?.id || '');
+  const [isPinned, setIsPinned] = useState(false);
+  const [linkUrl, setLinkUrl] = useState('');
+  const [linkText, setLinkText] = useState('');
+  const [expireDate, setExpireDate] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  if (!isOpen) return null;
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!title.trim()) newErrors.title = 'Title is required';
+    if (!description.trim()) newErrors.description = 'Description is required';
+    if (visibility === 'project' && !selectedProjectId) newErrors.project = 'Select a project';
+    if (visibility === 'team' && !targetTeam) newErrors.team = 'Select a team';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const input: CreateAnnouncementInput = {
+      project_id: visibility === 'project' ? selectedProjectId : null,
+      title: title.trim(),
+      description: description.trim(),
+      announcement_type: announcementType,
+      priority,
+      is_pinned: isPinned,
+      show_on_card: true,
+      image_url: null,
+      link_url: linkUrl.trim() || null,
+      link_text: linkText.trim() || null,
+      publish_date: new Date().toISOString(),
+      expire_date: expireDate ? new Date(expireDate).toISOString() : null,
+      is_active: true,
+      visibility,
+      target_team: visibility === 'team' ? (targetTeam as BoardTeam) : null,
+    };
+
+    await onSubmit(input);
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const inputClass = "w-full rounded-lg border border-[#D4D7E5] px-4 py-2 text-sm text-black bg-white focus:border-[#3F86FF] focus:outline-none";
+  const labelClass = "mb-1 block text-sm font-medium text-black/70";
+  const errorClass = "mt-1 text-xs text-red-500";
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4"
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="w-full max-w-lg rounded-2xl bg-white shadow-xl flex flex-col"
+        style={{ maxHeight: 'calc(100vh - 4rem)' }}
+      >
+        <div className="flex items-center justify-between p-6 pb-4 shrink-0">
+          <h2 className="text-xl font-semibold">New Announcement</h2>
+          <button
+            onClick={onClose}
+            className="text-black/50 hover:text-black"
+            aria-label="Close modal"
+          >
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4 overflow-y-auto px-6 pb-6">
+          {/* Visibility selector - only show Board Team / Club-Wide for directors/presidents */}
+          {isDirectorOrPresident && (
+            <div>
+              <label className={labelClass}>Who should see this? *</label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setVisibility('project')}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    visibility === 'project'
+                      ? 'bg-[#3F86FF] text-white'
+                      : 'bg-[#E5E7EB] text-black/70 hover:bg-[#D4D7E5]'
+                  }`}
+                >
+                  My Project
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setVisibility('team')}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    visibility === 'team'
+                      ? 'bg-[#3F86FF] text-white'
+                      : 'bg-[#E5E7EB] text-black/70 hover:bg-[#D4D7E5]'
+                  }`}
+                >
+                  Board Team
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setVisibility('club_wide')}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    visibility === 'club_wide'
+                      ? 'bg-[#3F86FF] text-white'
+                      : 'bg-[#E5E7EB] text-black/70 hover:bg-[#D4D7E5]'
+                  }`}
+                >
+                  Club-Wide
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Project selector (for project-scoped) */}
+          {visibility === 'project' && (
+            <div>
+              <label className={labelClass}>Project *</label>
+              <select
+                value={selectedProjectId}
+                onChange={(e) => setSelectedProjectId(e.target.value)}
+                className={inputClass}
+              >
+                <option value="">Select a project</option>
+                {userProjects.map((p) => (
+                  <option key={p.id} value={p.id}>{p.projectName}</option>
+                ))}
+              </select>
+              {errors.project && <p className={errorClass}>{errors.project}</p>}
+            </div>
+          )}
+
+          {/* Team selector (for team-scoped) */}
+          {visibility === 'team' && (
+            <div>
+              <label className={labelClass}>Board Team *</label>
+              <select
+                value={targetTeam}
+                onChange={(e) => setTargetTeam(e.target.value as BoardTeam)}
+                className={inputClass}
+              >
+                <option value="">Select a team</option>
+                {BOARD_TEAMS.map((t) => (
+                  <option key={t.value} value={t.value}>{t.label}</option>
+                ))}
+              </select>
+              {errors.team && <p className={errorClass}>{errors.team}</p>}
+            </div>
+          )}
+
+          <div>
+            <label className={labelClass}>Title *</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className={inputClass}
+              placeholder="Announcement title"
+            />
+            {errors.title && <p className={errorClass}>{errors.title}</p>}
+          </div>
+
+          <div>
+            <label className={labelClass}>Description *</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className={`${inputClass} min-h-[80px] resize-none`}
+              placeholder="What do you want to announce?"
+            />
+            {errors.description && <p className={errorClass}>{errors.description}</p>}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>Type</label>
+              <select
+                value={announcementType}
+                onChange={(e) => setAnnouncementType(e.target.value)}
+                className={inputClass}
+              >
+                {ANNOUNCEMENT_TYPES.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className={labelClass}>Priority</label>
+              <select
+                value={priority}
+                onChange={(e) => setPriority(e.target.value)}
+                className={inputClass}
+              >
+                {PRIORITY_OPTIONS.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className={labelClass}>Expiration Date</label>
+            <input
+              type="date"
+              value={expireDate}
+              onChange={(e) => setExpireDate(e.target.value)}
+              className={inputClass}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={labelClass}>Link URL</label>
+              <input
+                type="url"
+                value={linkUrl}
+                onChange={(e) => setLinkUrl(e.target.value)}
+                className={inputClass}
+                placeholder="https://..."
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Link Text</label>
+              <input
+                type="text"
+                value={linkText}
+                onChange={(e) => setLinkText(e.target.value)}
+                className={inputClass}
+                placeholder="e.g. Learn more"
+              />
+            </div>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-black/70">
+            <input
+              type="checkbox"
+              checked={isPinned}
+              onChange={(e) => setIsPinned(e.target.checked)}
+              className="rounded border-[#D4D7E5]"
+            />
+            Pin Announcement
+          </label>
+
+          <div className="flex justify-end gap-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg border border-[#D4D7E5] px-4 py-2 text-sm font-medium text-black/70 hover:bg-gray-50"
+              disabled={isSubmitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-lg bg-[#3F86FF] px-4 py-2 text-sm font-medium text-white hover:bg-[#346edd] disabled:opacity-50"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? 'Posting...' : 'Post Announcement'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/portal/dashboard/DashboardAnnouncementModal.tsx
+++ b/src/components/portal/dashboard/DashboardAnnouncementModal.tsx
@@ -153,6 +153,17 @@ export function DashboardAnnouncementModal({
                 </button>
                 <button
                   type="button"
+                  onClick={() => setVisibility('board')}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    visibility === 'board'
+                      ? 'bg-[#3F86FF] text-white'
+                      : 'bg-[#E5E7EB] text-black/70 hover:bg-[#D4D7E5]'
+                  }`}
+                >
+                  Board-Wide
+                </button>
+                <button
+                  type="button"
                   onClick={() => setVisibility('club_wide')}
                   className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
                     visibility === 'club_wide'

--- a/src/components/portal/project/MyProjectContent.tsx
+++ b/src/components/portal/project/MyProjectContent.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, useCallback } from "react";
 import Image from "next/image";
 import { FaGithub } from "react-icons/fa6";
 import { SiFigma, SiNotion } from "react-icons/si";
 import { useTasks } from '@/lib/hooks/useTasks';
+import { useUserRole } from '@/lib/hooks/useUserRole';
 import { getProjectById } from '@/lib/supabase/projectService';
+import { getProjectEvents, getProjectAnnouncements, createEvent, createAnnouncement } from '@/lib/supabase/eventsService';
 import { Project } from '@/lib/types/database';
+import { ProjectEvent, ProjectAnnouncement, CreateEventInput, CreateAnnouncementInput } from '@/types/events';
+import { AddEventModal } from './events/AddEventModal';
+import { AddAnnouncementModal } from './events/AddAnnouncementModal';
+import ProjectEventCard from '@/components/portal/ProjectEventCard';
+import ProjectAnnouncementCard from '@/components/portal/ProjectAnnouncementCard';
 
 const CARD_STYLES = {
   base: "rounded-2xl border border-[#D4D7E5] bg-white p-6 md:p-8 shadow-lg transform transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-xl",
@@ -103,8 +110,14 @@ interface MyProjectContentProps {
 
 export default function MyProjectContent({ projectId, currentUserId }: MyProjectContentProps) {
   const { tasks: allTasks, isLoading } = useTasks(projectId);
+  const { canPostEvents } = useUserRole(projectId, currentUserId);
   const [project, setProject] = useState<Project | null>(null);
   const [projectLoading, setProjectLoading] = useState(true);
+  const [events, setEvents] = useState<ProjectEvent[]>([]);
+  const [announcements, setAnnouncements] = useState<ProjectAnnouncement[]>([]);
+  const [showEventModal, setShowEventModal] = useState(false);
+  const [showAnnouncementModal, setShowAnnouncementModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     async function fetchProject() {
@@ -120,6 +133,47 @@ export default function MyProjectContent({ projectId, currentUserId }: MyProject
     }
     fetchProject();
   }, [projectId]);
+
+  const fetchEvents = useCallback(async () => {
+    const data = await getProjectEvents(projectId, { includeCompleted: false });
+    setEvents(data);
+  }, [projectId]);
+
+  const fetchAnnouncements = useCallback(async () => {
+    const data = await getProjectAnnouncements(projectId);
+    setAnnouncements(data);
+  }, [projectId]);
+
+  useEffect(() => {
+    fetchEvents();
+    fetchAnnouncements();
+  }, [fetchEvents, fetchAnnouncements]);
+
+  const handleCreateEvent = async (input: CreateEventInput) => {
+    setIsSubmitting(true);
+    try {
+      await createEvent(input);
+      await fetchEvents();
+      setShowEventModal(false);
+    } catch (err) {
+      console.error('Failed to create event:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCreateAnnouncement = async (input: CreateAnnouncementInput) => {
+    setIsSubmitting(true);
+    try {
+      await createAnnouncement(input);
+      await fetchAnnouncements();
+      setShowAnnouncementModal(false);
+    } catch (err) {
+      console.error('Failed to create announcement:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   const myTasks = useMemo(() => {
     return allTasks.filter(task => 
@@ -265,6 +319,58 @@ export default function MyProjectContent({ projectId, currentUserId }: MyProject
             </div>
           )}
         </Section>
+
+        <section className="space-y-4 transform transition-all duration-300 ease-out">
+          <div className="flex items-center justify-between">
+            <h2 className={CARD_STYLES.titleDefault}>Upcoming Events</h2>
+            {canPostEvents && (
+              <button
+                onClick={() => setShowEventModal(true)}
+                className="flex items-center gap-1.5 rounded-lg bg-[#3F86FF] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#346edd] transition-colors"
+              >
+                <span className="text-base leading-none">+</span>
+                <span>Add Event</span>
+              </button>
+            )}
+          </div>
+          <div className={CARD_STYLES.base}>
+            {events.length === 0 ? (
+              <p className="text-sm text-black/50">No upcoming events</p>
+            ) : (
+              <div className="space-y-4">
+                {events.map(event => (
+                  <ProjectEventCard key={event.id} event={event} compact />
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-4 transform transition-all duration-300 ease-out">
+          <div className="flex items-center justify-between">
+            <h2 className={CARD_STYLES.titleDefault}>Announcements</h2>
+            {canPostEvents && (
+              <button
+                onClick={() => setShowAnnouncementModal(true)}
+                className="flex items-center gap-1.5 rounded-lg bg-[#3F86FF] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#346edd] transition-colors"
+              >
+                <span className="text-base leading-none">+</span>
+                <span>Add Announcement</span>
+              </button>
+            )}
+          </div>
+          <div className={CARD_STYLES.base}>
+            {announcements.length === 0 ? (
+              <p className="text-sm text-black/50">No announcements</p>
+            ) : (
+              <div className="space-y-4">
+                {announcements.map(announcement => (
+                  <ProjectAnnouncementCard key={announcement.id} announcement={announcement} compact />
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
       </div>
 
       <div className="space-y-14">
@@ -333,6 +439,22 @@ export default function MyProjectContent({ projectId, currentUserId }: MyProject
           </div>
         </Section>
       </div>
+
+      <AddEventModal
+        isOpen={showEventModal}
+        onClose={() => setShowEventModal(false)}
+        onSubmit={handleCreateEvent}
+        projectId={projectId}
+        isSubmitting={isSubmitting}
+      />
+
+      <AddAnnouncementModal
+        isOpen={showAnnouncementModal}
+        onClose={() => setShowAnnouncementModal(false)}
+        onSubmit={handleCreateAnnouncement}
+        projectId={projectId}
+        isSubmitting={isSubmitting}
+      />
     </div>
   );
 }

--- a/src/components/portal/project/events/AddAnnouncementModal.tsx
+++ b/src/components/portal/project/events/AddAnnouncementModal.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from 'react';
+import { AnnouncementForm } from './AnnouncementForm';
+import { CreateAnnouncementInput } from '@/types/events';
+
+interface AddAnnouncementModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (input: CreateAnnouncementInput) => Promise<void>;
+  projectId: string;
+  isSubmitting?: boolean;
+}
+
+export function AddAnnouncementModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  projectId,
+  isSubmitting = false,
+}: AddAnnouncementModalProps) {
+  if (!isOpen) return null;
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleBackdropClick}
+    >
+      <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl">
+        <div className="mb-6 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Create Announcement</h2>
+          <button
+            onClick={onClose}
+            className="text-black/50 hover:text-black"
+            aria-label="Close modal"
+          >
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <AnnouncementForm
+          projectId={projectId}
+          onSubmit={onSubmit}
+          onCancel={onClose}
+          isSubmitting={isSubmitting}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/project/events/AddEventModal.tsx
+++ b/src/components/portal/project/events/AddEventModal.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from 'react';
+import { EventForm } from './EventForm';
+import { CreateEventInput } from '@/types/events';
+
+interface AddEventModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (input: CreateEventInput) => Promise<void>;
+  projectId: string;
+  isSubmitting?: boolean;
+}
+
+export function AddEventModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  projectId,
+  isSubmitting = false,
+}: AddEventModalProps) {
+  if (!isOpen) return null;
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleBackdropClick}
+    >
+      <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-xl">
+        <div className="mb-6 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Create New Event</h2>
+          <button
+            onClick={onClose}
+            className="text-black/50 hover:text-black"
+            aria-label="Close modal"
+          >
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <EventForm
+          projectId={projectId}
+          onSubmit={onSubmit}
+          onCancel={onClose}
+          isSubmitting={isSubmitting}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/project/events/AnnouncementForm.tsx
+++ b/src/components/portal/project/events/AnnouncementForm.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import React, { useState } from 'react';
+import { CreateAnnouncementInput } from '@/types/events';
+
+interface AnnouncementFormProps {
+  projectId: string;
+  onSubmit: (input: CreateAnnouncementInput) => Promise<void>;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+const ANNOUNCEMENT_TYPES = [
+  { value: 'general', label: 'General' },
+  { value: 'update', label: 'Update' },
+  { value: 'milestone', label: 'Milestone' },
+  { value: 'recruitment', label: 'Recruitment' },
+  { value: 'launch', label: 'Launch' },
+];
+
+const PRIORITY_OPTIONS = [
+  { value: 'low', label: 'Low' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'high', label: 'High' },
+  { value: 'urgent', label: 'Urgent' },
+];
+
+export function AnnouncementForm({
+  projectId,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}: AnnouncementFormProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [announcementType, setAnnouncementType] = useState('general');
+  const [priority, setPriority] = useState('normal');
+  const [isPinned, setIsPinned] = useState(false);
+  const [showOnCard, setShowOnCard] = useState(true);
+  const [linkUrl, setLinkUrl] = useState('');
+  const [linkText, setLinkText] = useState('');
+  const [expireDate, setExpireDate] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!title.trim()) newErrors.title = 'Title is required';
+    if (!description.trim()) newErrors.description = 'Description is required';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const input: CreateAnnouncementInput = {
+      project_id: projectId,
+      title: title.trim(),
+      description: description.trim(),
+      announcement_type: announcementType,
+      priority,
+      is_pinned: isPinned,
+      show_on_card: showOnCard,
+      image_url: null,
+      link_url: linkUrl.trim() || null,
+      link_text: linkText.trim() || null,
+      publish_date: new Date().toISOString(),
+      expire_date: expireDate ? new Date(expireDate).toISOString() : null,
+      is_active: true,
+      visibility: 'project',
+      target_team: null,
+    };
+
+    await onSubmit(input);
+  };
+
+  const inputClass = "w-full rounded-lg border border-[#D4D7E5] px-4 py-2 text-sm focus:border-[#3F86FF] focus:outline-none";
+  const labelClass = "mb-1 block text-sm font-medium text-black/70";
+  const errorClass = "mt-1 text-xs text-red-500";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className={labelClass}>Title *</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className={inputClass}
+          placeholder="Announcement title"
+        />
+        {errors.title && <p className={errorClass}>{errors.title}</p>}
+      </div>
+
+      <div>
+        <label className={labelClass}>Description *</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className={`${inputClass} min-h-[80px] resize-none`}
+          placeholder="What do you want to announce?"
+        />
+        {errors.description && <p className={errorClass}>{errors.description}</p>}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className={labelClass}>Type</label>
+          <select
+            value={announcementType}
+            onChange={(e) => setAnnouncementType(e.target.value)}
+            className={inputClass}
+          >
+            {ANNOUNCEMENT_TYPES.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={labelClass}>Priority</label>
+          <select
+            value={priority}
+            onChange={(e) => setPriority(e.target.value)}
+            className={inputClass}
+          >
+            {PRIORITY_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label className={labelClass}>Expiration Date</label>
+        <input
+          type="date"
+          value={expireDate}
+          onChange={(e) => setExpireDate(e.target.value)}
+          className={inputClass}
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className={labelClass}>Link URL</label>
+          <input
+            type="url"
+            value={linkUrl}
+            onChange={(e) => setLinkUrl(e.target.value)}
+            className={inputClass}
+            placeholder="https://..."
+          />
+        </div>
+        <div>
+          <label className={labelClass}>Link Text</label>
+          <input
+            type="text"
+            value={linkText}
+            onChange={(e) => setLinkText(e.target.value)}
+            className={inputClass}
+            placeholder="e.g. Learn more"
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-6">
+        <label className="flex items-center gap-2 text-sm text-black/70">
+          <input
+            type="checkbox"
+            checked={isPinned}
+            onChange={(e) => setIsPinned(e.target.checked)}
+            className="rounded border-[#D4D7E5]"
+          />
+          Pin Announcement
+        </label>
+        <label className="flex items-center gap-2 text-sm text-black/70">
+          <input
+            type="checkbox"
+            checked={showOnCard}
+            onChange={(e) => setShowOnCard(e.target.checked)}
+            className="rounded border-[#D4D7E5]"
+          />
+          Show on Card
+        </label>
+      </div>
+
+      <div className="flex justify-end gap-3 pt-4">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg border border-[#D4D7E5] px-4 py-2 text-sm font-medium text-black/70 hover:bg-gray-50"
+          disabled={isSubmitting}
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="rounded-lg bg-[#3F86FF] px-4 py-2 text-sm font-medium text-white hover:bg-[#346edd] disabled:opacity-50"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Posting...' : 'Post Announcement'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/portal/project/events/EventForm.tsx
+++ b/src/components/portal/project/events/EventForm.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import React, { useState } from 'react';
+import { CreateEventInput } from '@/types/events';
+
+interface EventFormProps {
+  projectId: string;
+  onSubmit: (input: CreateEventInput) => Promise<void>;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+const LOCATION_TYPES = [
+  { value: 'in_person', label: 'In Person' },
+  { value: 'virtual', label: 'Virtual' },
+  { value: 'hybrid', label: 'Hybrid' },
+];
+
+export function EventForm({
+  projectId,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+}: EventFormProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [eventDate, setEventDate] = useState('');
+  const [eventTimeDisplay, setEventTimeDisplay] = useState('');
+  const [location, setLocation] = useState('');
+  const [locationType, setLocationType] = useState('in_person');
+  const [virtualLink, setVirtualLink] = useState('');
+  const [rsvpLink, setRsvpLink] = useState('');
+  const [rsvpRequired, setRsvpRequired] = useState(false);
+  const [isPublic, setIsPublic] = useState(true);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!title.trim()) newErrors.title = 'Event title is required';
+    if (!eventDate) newErrors.eventDate = 'Event date is required';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const input: CreateEventInput = {
+      project_id: projectId,
+      title: title.trim(),
+      description: description.trim() || null,
+      event_type: null,
+      event_date: new Date(eventDate).toISOString(),
+      event_time_display: eventTimeDisplay || null,
+      end_date: null,
+      location: location.trim() || null,
+      location_type: locationType,
+      virtual_link: virtualLink.trim() || null,
+      rsvp_link: rsvpLink.trim() || null,
+      rsvp_required: rsvpRequired,
+      max_attendees: null,
+      image_url: null,
+      status: 'upcoming',
+      is_public: isPublic,
+      visibility: 'project',
+      target_team: null,
+    };
+
+    await onSubmit(input);
+  };
+
+  const inputClass = "w-full rounded-lg border border-[#D4D7E5] px-4 py-2 text-sm focus:border-[#3F86FF] focus:outline-none";
+  const labelClass = "mb-1 block text-sm font-medium text-black/70";
+  const errorClass = "mt-1 text-xs text-red-500";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className={labelClass}>Event Title *</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className={inputClass}
+          placeholder="Enter event title"
+        />
+        {errors.title && <p className={errorClass}>{errors.title}</p>}
+      </div>
+
+      <div>
+        <label className={labelClass}>Description</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className={`${inputClass} min-h-[80px] resize-none`}
+          placeholder="Describe the event"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className={labelClass}>Event Date *</label>
+          <input
+            type="date"
+            value={eventDate}
+            onChange={(e) => setEventDate(e.target.value)}
+            className={inputClass}
+          />
+          {errors.eventDate && <p className={errorClass}>{errors.eventDate}</p>}
+        </div>
+        <div>
+          <label className={labelClass}>Time Display</label>
+          <input
+            type="text"
+            value={eventTimeDisplay}
+            onChange={(e) => setEventTimeDisplay(e.target.value)}
+            className={inputClass}
+            placeholder="e.g. 2:00 PM - 4:00 PM"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className={labelClass}>Location Type</label>
+          <select
+            value={locationType}
+            onChange={(e) => setLocationType(e.target.value)}
+            className={inputClass}
+          >
+            {LOCATION_TYPES.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={labelClass}>Location</label>
+          <input
+            type="text"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            className={inputClass}
+            placeholder="e.g. Boelter Hall 3400"
+          />
+        </div>
+      </div>
+
+      {(locationType === 'virtual' || locationType === 'hybrid') && (
+        <div>
+          <label className={labelClass}>Virtual Link</label>
+          <input
+            type="url"
+            value={virtualLink}
+            onChange={(e) => setVirtualLink(e.target.value)}
+            className={inputClass}
+            placeholder="https://zoom.us/..."
+          />
+        </div>
+      )}
+
+      <div>
+        <label className={labelClass}>RSVP Link</label>
+        <input
+          type="url"
+          value={rsvpLink}
+          onChange={(e) => setRsvpLink(e.target.value)}
+          className={inputClass}
+          placeholder="https://..."
+        />
+      </div>
+
+      <div className="flex gap-6">
+        <label className="flex items-center gap-2 text-sm text-black/70">
+          <input
+            type="checkbox"
+            checked={rsvpRequired}
+            onChange={(e) => setRsvpRequired(e.target.checked)}
+            className="rounded border-[#D4D7E5]"
+          />
+          RSVP Required
+        </label>
+        <label className="flex items-center gap-2 text-sm text-black/70">
+          <input
+            type="checkbox"
+            checked={isPublic}
+            onChange={(e) => setIsPublic(e.target.checked)}
+            className="rounded border-[#D4D7E5]"
+          />
+          Public Event
+        </label>
+      </div>
+
+      <div className="flex justify-end gap-3 pt-4">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg border border-[#D4D7E5] px-4 py-2 text-sm font-medium text-black/70 hover:bg-gray-50"
+          disabled={isSubmitting}
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="rounded-lg bg-[#3F86FF] px-4 py-2 text-sm font-medium text-white hover:bg-[#346edd] disabled:opacity-50"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Creating...' : 'Create Event'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/hooks/useUserRole.ts
+++ b/src/lib/hooks/useUserRole.ts
@@ -1,18 +1,22 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../supabase/client';
 
+type ProjectRole = 'project lead' | 'project member' | null;
+
 interface UseUserRoleReturn {
-  role: 'member' | 'lead' | 'manager' | null;
+  role: ProjectRole;
   isLoading: boolean;
   error: string | null;
   canCreateTasks: boolean;
+  canPostEvents: boolean;
 }
 
 /**
  * hook to get user's role in a specific project
+ * joins project_members with roles table via rbac_role_id
  */
 export function useUserRole(projectId: string | null, userId: string | null): UseUserRoleReturn {
-  const [role, setRole] = useState<'member' | 'lead' | 'manager' | null>(null);
+  const [role, setRole] = useState<ProjectRole>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,7 +32,10 @@ export function useUserRole(projectId: string | null, userId: string | null): Us
 
       const { data, error } = await supabase
         .from('project_members')
-        .select('role')
+        .select(`
+          rbac_role_id,
+          roles!inner(name)
+        `)
         .eq('project_id', projectId)
         .eq('user_id', userId)
         .single();
@@ -37,7 +44,9 @@ export function useUserRole(projectId: string | null, userId: string | null): Us
         setError(error.message);
         setRole(null);
       } else {
-        setRole(data?.role || null);
+        const roles = data?.roles as unknown as { name: string } | { name: string }[] | null;
+        const roleName = Array.isArray(roles) ? roles[0]?.name : roles?.name ?? null;
+        setRole(roleName as ProjectRole);
       }
 
       setIsLoading(false);
@@ -46,12 +55,14 @@ export function useUserRole(projectId: string | null, userId: string | null): Us
     fetchUserRole();
   }, [projectId, userId]);
 
-  const canCreateTasks = role === 'lead' || role === 'manager';
+  const canCreateTasks = role === 'project lead';
+  const canPostEvents = role === 'project lead';
 
   return {
     role,
     isLoading,
     error,
     canCreateTasks,
+    canPostEvents,
   };
 }

--- a/src/lib/supabase/eventsService.ts
+++ b/src/lib/supabase/eventsService.ts
@@ -1,5 +1,5 @@
 import { supabase } from './client';
-import { ProjectEvent, ProjectAnnouncement } from '@/types/events';
+import { ProjectEvent, ProjectAnnouncement, CreateEventInput, CreateAnnouncementInput } from '@/types/events';
 
 /**
  * Get all upcoming events across all projects
@@ -137,4 +137,42 @@ export async function getProjectAnnouncements(
   }
 
   return (data || []) as ProjectAnnouncement[];
+}
+
+/**
+ * Create a new event for a project
+ * RLS enforces that only the project's lead can create events
+ */
+export async function createEvent(input: CreateEventInput): Promise<ProjectEvent | null> {
+  const { data, error } = await supabase
+    .from('project_events')
+    .insert(input)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error creating event:', error);
+    throw new Error(error.message);
+  }
+
+  return data as ProjectEvent;
+}
+
+/**
+ * Create a new announcement for a project
+ * RLS enforces that only the project's lead (or director/president for team/club-wide) can create
+ */
+export async function createAnnouncement(input: CreateAnnouncementInput): Promise<ProjectAnnouncement | null> {
+  const { data, error } = await supabase
+    .from('project_announcements')
+    .insert(input)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error creating announcement:', error);
+    throw new Error(error.message);
+  }
+
+  return data as ProjectAnnouncement;
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,6 +1,9 @@
+export type AnnouncementVisibility = 'project' | 'team' | 'club_wide';
+export type BoardTeam = 'tech' | 'finance' | 'marketing' | 'design';
+
 export interface ProjectEvent {
   id: string;
-  project_id: string;
+  project_id: string | null;
   title: string;
   description: string | null;
   event_type: string | null;
@@ -16,13 +19,15 @@ export interface ProjectEvent {
   image_url: string | null;
   status: string;
   is_public: boolean;
+  visibility: AnnouncementVisibility;
+  target_team: BoardTeam | null;
   created_at: string;
   updated_at: string;
 }
 
 export interface ProjectAnnouncement {
   id: string;
-  project_id: string;
+  project_id: string | null;
   title: string;
   description: string;
   announcement_type: string | null;
@@ -35,6 +40,11 @@ export interface ProjectAnnouncement {
   publish_date: string;
   expire_date: string | null;
   is_active: boolean;
+  visibility: AnnouncementVisibility;
+  target_team: BoardTeam | null;
   created_at: string;
   updated_at: string;
 }
+
+export type CreateEventInput = Omit<ProjectEvent, 'id' | 'created_at' | 'updated_at'>;
+export type CreateAnnouncementInput = Omit<ProjectAnnouncement, 'id' | 'created_at' | 'updated_at'>;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,4 +1,4 @@
-export type AnnouncementVisibility = 'project' | 'team' | 'club_wide';
+export type AnnouncementVisibility = 'project' | 'team' | 'board' | 'club_wide';
 export type BoardTeam = 'tech' | 'finance' | 'marketing' | 'design';
 
 export interface ProjectEvent {


### PR DESCRIPTION
## Summary
- Adds visibility system (`project` / `team` / `club_wide`) for announcements and events
- Dashboard announcement modal with role-based visibility options (directors/presidents/board members see team & club-wide, external leads and external members see project only)
- Event and announcement creation UI on project overview page
- Adds `createEvent` and `createAnnouncement` service functions with RLS-enforced permissions

Closes #227