### PR TITLE
Logo uploading with settings page and UI refactor

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -39,7 +39,7 @@ export default function SignupPage() {
 
     const supabase = createClient();
 
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: {
@@ -54,6 +54,26 @@ export default function SignupPage() {
       setError(error.message);
       setIsLoading(false);
     } else {
+      const user = data.user;
+      if (user) {
+        const { error: profileError } = await supabase
+          .from('profiles')
+          .upsert(
+            {
+              id: user.id,
+              email: user.email,
+              first_name: firstName.trim(),
+              last_name: lastName.trim(),
+            },
+            { onConflict: 'id' }
+          );
+
+        if (profileError) {
+          setError(profileError.message);
+          setIsLoading(false);
+          return;
+        }
+      }
       // Redirect to portal after successful signup
       router.push("/portal");
     }

--- a/src/app/(portal)/portal/my-project/page.tsx
+++ b/src/app/(portal)/portal/my-project/page.tsx
@@ -1,81 +1,59 @@
-'use client';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { useAuth } from '@/lib/hooks/useAuth';
-import { useUserProject } from '@/lib/hooks/useUserProject';
+export default async function MyProjectPage() {
+  const supabase = await createClient();
+  const { data: { user }, error } = await supabase.auth.getUser();
 
-export default function MyProjectPage() {
-  const router = useRouter();
-  const { userId, isLoading: authLoading } = useAuth();
-  const { project, isLoading: projectLoading } = useUserProject(userId);
-
-  useEffect(() => {
-    if (!authLoading && !projectLoading && project) {
-      router.replace(`/portal/projects/${project.project_id}/overview`);
-    }
-  }, [authLoading, projectLoading, project, router]);
-
-  if (authLoading || projectLoading) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500" />
-      </div>
-    );
+  if (error || !user) {
+    redirect('/login');
   }
 
-  if (!userId) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="text-center">
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
-            Please Sign In
-          </h2>
-          <p className="text-gray-500">
-            You need to be signed in to view your project.
-          </p>
-        </div>
-      </div>
-    );
+  const { data: membership, error: membershipError } = await supabase
+    .from('project_members')
+    .select('project_id')
+    .eq('user_id', user.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (!membershipError && membership?.project_id) {
+    redirect(`/portal/projects/${membership.project_id}/overview`);
   }
 
-  if (!project) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="text-center max-w-md px-4">
-          <div className="mb-4">
-            <div className="mx-auto h-16 w-16 rounded-full bg-gray-100 flex items-center justify-center">
-              <svg
-                className="h-8 w-8 text-gray-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-                />
-              </svg>
-            </div>
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="text-center max-w-md px-4">
+        <div className="mb-4">
+          <div className="mx-auto h-16 w-16 rounded-full bg-gray-100 flex items-center justify-center">
+            <svg
+              className="h-8 w-8 text-gray-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+              />
+            </svg>
           </div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
-            You&apos;re Not in a Project Yet
-          </h2>
-          <p className="text-gray-500 mb-6">
-            You haven&apos;t been added to any project. Contact a project lead to get invited to a project.
-          </p>
-          <button
-            onClick={() => router.push('/portal/directory')}
-            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-          >
-            Browse Projects
-          </button>
         </div>
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">
+          You&apos;re Not in a Project Yet
+        </h2>
+        <p className="text-gray-500 mb-6">
+          You haven&apos;t been added to any project. Contact a project lead to get invited to a project.
+        </p>
+        <Link
+          href="/portal/directory"
+          className="inline-flex px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+        >
+          Browse Projects
+        </Link>
       </div>
-    );
-  }
-
-  return null;
+    </div>
+  );
 }

--- a/src/app/(portal)/portal/projects/(with-sidebar)/[projectId]/layout.tsx
+++ b/src/app/(portal)/portal/projects/(with-sidebar)/[projectId]/layout.tsx
@@ -10,19 +10,21 @@ export default async function ProjectLayout({ children, params }: ProjectLayoutP
   const { projectId } = await params;
 
   let projectName: string | undefined;
+  let logoUrl: string | undefined;
   if (projectId) {
     const supabase = await createClient();
     const { data } = await supabase
       .from('projects')
-      .select('projectName')
+      .select('projectName, logoUrl')
       .eq('id', projectId)
       .single();
     projectName = data?.projectName ?? undefined;
+    logoUrl = data?.logoUrl ?? undefined;
   }
 
   return (
     <div className="flex flex-1 text-black">
-      <MembershipPortalSidebar className="flex-shrink-0" projectName={projectName} />
+      <MembershipPortalSidebar className="flex-shrink-0" projectName={projectName} logoUrl={logoUrl} />
       <div className="flex-1 px-6 py-8 md:px-10 md:py-10">
         <div className="mx-auto max-w-5xl space-y-6">
           {children}

--- a/src/app/(portal)/portal/projects/(with-sidebar)/[projectId]/layout.tsx
+++ b/src/app/(portal)/portal/projects/(with-sidebar)/[projectId]/layout.tsx
@@ -1,10 +1,33 @@
-"use client";
+import MembershipPortalSidebar from "@/components/portal/project/MembershipPortalSidebar";
+import { createClient } from "@/lib/supabase/server";
 
 interface ProjectLayoutProps {
   children: React.ReactNode;
   params: Promise<{ projectId: string }>;
 }
 
-export default function ProjectLayout({ children }: ProjectLayoutProps) {
-  return <>{children}</>;
+export default async function ProjectLayout({ children, params }: ProjectLayoutProps) {
+  const { projectId } = await params;
+
+  let projectName: string | undefined;
+  if (projectId) {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from('projects')
+      .select('projectName')
+      .eq('id', projectId)
+      .single();
+    projectName = data?.projectName ?? undefined;
+  }
+
+  return (
+    <div className="flex flex-1 text-black">
+      <MembershipPortalSidebar className="flex-shrink-0" projectName={projectName} />
+      <div className="flex-1 px-6 py-8 md:px-10 md:py-10">
+        <div className="mx-auto max-w-5xl space-y-6">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/app/(portal)/portal/projects/(with-sidebar)/[projectId]/overview/page.tsx
+++ b/src/app/(portal)/portal/projects/(with-sidebar)/[projectId]/overview/page.tsx
@@ -3,31 +3,11 @@
 import MyProjectContent from "@/components/portal/project/MyProjectContent";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { use } from 'react';
-import { useState, useEffect } from 'react';
-import { getProjectById } from '@/lib/supabase/projectService';
 
 // TODO: add route guard to verify user is a project member
 export default function Page({ params }: { params: Promise<{ projectId: string }> }) {
-  const { userId, isLoading, error } = useAuth();
+  const { userId, user, isLoading, error } = useAuth();
   const { projectId } = use(params);
-  const [project, setProject] = useState<any>(null);
-  const [projectLoading, setProjectLoading] = useState(true);
-
-  useEffect(() => {
-    async function fetchProject() {
-      try {
-        setProjectLoading(true);
-        const data = await getProjectById(projectId);
-        setProject(data);
-      } catch (err) {
-        console.error('Failed to load project:', err);
-      } finally {
-        setProjectLoading(false);
-      }
-    }
-    fetchProject();
-  }, [projectId]);
-
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -46,11 +26,6 @@ export default function Page({ params }: { params: Promise<{ projectId: string }
 
   return (
     <>
-      <section className="space-y-2">
-        <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">
-          {projectLoading ? "Loading..." : (project?.projectName || "My Project")}
-        </h1>
-      </section>
       <MyProjectContent 
         projectId={projectId}
         currentUserId={userId}

--- a/src/app/(portal)/portal/projects/(with-sidebar)/[projectId]/settings/page.tsx
+++ b/src/app/(portal)/portal/projects/(with-sidebar)/[projectId]/settings/page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { use, useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/lib/hooks/useAuth';
+import { getProjectById, updateProjectSettings, uploadProjectLogo } from '@/lib/supabase/projectService';
+import { Project } from '@/types/project';
+
+interface SettingsField {
+  key: keyof Pick<Project, 'githubUrl' | 'figmaUrl' | 'notionUrl'>;
+  label: string;
+  placeholder: string;
+}
+
+const LINK_FIELDS: SettingsField[] = [
+  { key: 'githubUrl', label: 'GitHub URL', placeholder: 'https://github.com/org/repo' },
+  { key: 'figmaUrl', label: 'Figma URL', placeholder: 'https://figma.com/file/...' },
+  { key: 'notionUrl', label: 'Notion URL', placeholder: 'https://notion.so/...' },
+];
+
+export default function SettingsPage({ params }: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = use(params);
+  const { userId, isLoading: authLoading, error: authError } = useAuth();
+
+  const [project, setProject] = useState<Project | null>(null);
+  const [projectLoading, setProjectLoading] = useState(true);
+
+  const [githubUrl, setGithubUrl] = useState('');
+  const [figmaUrl, setFigmaUrl] = useState('');
+  const [notionUrl, setNotionUrl] = useState('');
+
+  const [logoPreview, setLogoPreview] = useState<string | null>(null);
+  const [logoFile, setLogoFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  useEffect(() => {
+    if (!projectId) return;
+    const load = async () => {
+      setProjectLoading(true);
+      const data = await getProjectById(projectId);
+      setProject(data);
+      if (data) {
+        setGithubUrl(data.githubUrl ?? '');
+        setFigmaUrl(data.figmaUrl ?? '');
+        setNotionUrl(data.notionUrl ?? '');
+        setLogoPreview(data.logoUrl ?? null);
+      }
+      setProjectLoading(false);
+    };
+    load();
+  }, [projectId]);
+
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setLogoFile(file);
+    setLogoPreview(URL.createObjectURL(file));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveStatus('idle');
+
+    let logoUrl = project?.logoUrl ?? null;
+
+    if (logoFile) {
+      const uploaded = await uploadProjectLogo(projectId, logoFile);
+      if (uploaded) logoUrl = uploaded;
+    }
+
+    const updated = await updateProjectSettings(projectId, {
+      githubUrl: githubUrl || null,
+      figmaUrl: figmaUrl || null,
+      notionUrl: notionUrl || null,
+      logoUrl,
+    });
+
+    setSaving(false);
+    setSaveStatus(updated ? 'success' : 'error');
+
+    if (updated) {
+      setProject(updated);
+      setTimeout(() => setSaveStatus('idle'), 3000);
+    }
+  };
+
+  if (authLoading || projectLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-sm text-black/50">Loading...</p>
+      </div>
+    );
+  }
+
+  if (authError || !userId) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-sm text-red-500">Please sign in to view this page</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <section className="space-y-2">
+        <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-black">Settings</h1>
+        <p className="text-sm text-black/50">Manage your project details and integrations</p>
+      </section>
+
+      <div className="mt-8 space-y-8 max-w-2xl">
+
+        {/* Logo */}
+        <div className="rounded-2xl border border-[#D4D7E5] bg-white p-6 md:p-8 space-y-4">
+          <h2 className="text-xl font-semibold text-black">Project Logo</h2>
+          <div className="flex items-center gap-6">
+            {logoPreview && (
+              <div className="h-20 w-20 rounded-lg overflow-hidden flex items-center justify-center flex-shrink-0">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={logoPreview}
+                  alt="Project logo"
+                  className="h-full w-full object-contain"
+                />
+              </div>
+            )}
+            <div className="space-y-2">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="px-4 py-2 rounded-lg border border-[#D4D7E5] text-sm font-medium text-black hover:bg-gray-50 transition-colors"
+              >
+                Upload image
+              </button>
+              {logoPreview && logoPreview !== (project?.logoUrl ?? null) && (
+                <p className="text-xs text-black/50">New logo selected — save to apply</p>
+              )}
+              <p className="text-xs text-black/40">PNG, JPG, SVG up to 5 MB</p>
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleLogoChange}
+            />
+          </div>
+        </div>
+
+        {/* Links */}
+        <div className="rounded-2xl border border-[#D4D7E5] bg-white p-6 md:p-8 space-y-5">
+          <h2 className="text-xl font-semibold text-black">Project Links</h2>
+          {LINK_FIELDS.map(({ key, label, placeholder }) => {
+            const value = key === 'githubUrl' ? githubUrl : key === 'figmaUrl' ? figmaUrl : notionUrl;
+            const setter = key === 'githubUrl' ? setGithubUrl : key === 'figmaUrl' ? setFigmaUrl : setNotionUrl;
+            return (
+              <div key={key} className="space-y-1.5">
+                <label className="block text-sm font-medium text-black/70">{label}</label>
+                <input
+                  type="url"
+                  value={value}
+                  onChange={(e) => setter(e.target.value)}
+                  placeholder={placeholder}
+                  className="w-full rounded-lg border border-[#D4D7E5] px-3 py-2 text-sm text-black placeholder:text-black/30 focus:outline-none focus:ring-2 focus:ring-[#3F86FF]/40"
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Save */}
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="px-5 py-2.5 rounded-lg bg-[#3F86FF] text-white text-sm font-semibold hover:bg-[#2d74ee] disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Saving…' : 'Save changes'}
+          </button>
+          {saveStatus === 'success' && (
+            <p className="text-sm text-green-600">Changes saved!</p>
+          )}
+          {saveStatus === 'error' && (
+            <p className="text-sm text-red-500">Failed to save. Please try again.</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(portal)/portal/projects/(with-sidebar)/layout.tsx
+++ b/src/app/(portal)/portal/projects/(with-sidebar)/layout.tsx
@@ -1,20 +1,7 @@
-"use client";
-
-import MembershipPortalSidebar from "@/components/portal/project/MembershipPortalSidebar";
-
 export default function ProjectsSidebarLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div className="flex flex-1 text-black">
-      <MembershipPortalSidebar className="flex-shrink-0" />
-      <div className="flex-1 px-6 py-8 md:px-10 md:py-10">
-        <div className="mx-auto max-w-5xl space-y-6">
-          {children}
-        </div>
-      </div>
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/src/components/portal/project/MembershipPortalSidebar.tsx
+++ b/src/components/portal/project/MembershipPortalSidebar.tsx
@@ -38,7 +38,7 @@ const BASE_ITEMS = [
 ];
 
 export default function MembershipPortalSidebar({
-  projectName = "Project Name",
+  projectName,
   items,
   className = "",
 }: MembershipPortalSidebarProps) {
@@ -50,10 +50,10 @@ export default function MembershipPortalSidebar({
     return match ? match[1] : null;
   }, [pathname]);
 
-  // avigation items with  projectId
+  // Build nav items using the projectId extracted from the current path
   const navItems = useMemo(() => {
     if (items) return items;
-    
+
     if (!projectId) return [];
 
     return BASE_ITEMS.map(item => ({

--- a/src/components/portal/project/MembershipPortalSidebar.tsx
+++ b/src/components/portal/project/MembershipPortalSidebar.tsx
@@ -8,6 +8,7 @@ import {
   RxRows,
   RxPerson,
   RxFileText,
+  RxGear,
 } from "react-icons/rx";
 
 export type MembershipPortalSidebarItem = {
@@ -19,6 +20,7 @@ export type MembershipPortalSidebarItem = {
 
 export interface MembershipPortalSidebarProps {
   projectName?: string;
+  logoUrl?: string;
   items?: MembershipPortalSidebarItem[];
   className?: string;
 }
@@ -35,10 +37,12 @@ const BASE_ITEMS = [
   { id: "list", label: "List", path: "list", icon: RxRows },
   { id: "members", label: "Members", path: "members", icon: RxPerson },
   { id: "docs", label: "Docs", path: "docs", icon: RxFileText },
+  { id: "settings", label: "Settings", path: "settings", icon: RxGear },
 ];
 
 export default function MembershipPortalSidebar({
   projectName,
+  logoUrl,
   items,
   className = "",
 }: MembershipPortalSidebarProps) {
@@ -77,7 +81,12 @@ export default function MembershipPortalSidebar({
       className={`flex min-h-screen flex-col border-r-[2px] border-[#CDCCC8] bg-white px-6 py-6 w-60 ${className}`}
     >
       <div className="mt-4 mb-12 flex items-center gap-3">
-        <div className="h-10 w-10 rounded-full bg-[#FFB3D9]" />
+        {logoUrl && (
+          <div className="h-10 w-10 rounded-lg overflow-hidden flex items-center justify-center flex-shrink-0">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={logoUrl} alt="Project logo" className="h-full w-full object-contain" />
+          </div>
+        )}
         <div className="flex flex-col">
           <span
             className="font-bold"

--- a/src/components/portal/project/MyProjectContent.tsx
+++ b/src/components/portal/project/MyProjectContent.tsx
@@ -10,7 +10,7 @@ import { Project } from '@/lib/types/database';
 
 const CARD_STYLES = {
   base: "rounded-2xl border border-[#D4D7E5] bg-white p-6 md:p-8 shadow-lg transform transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-xl",
-  titleDefault: "mb-3 text-xl font-semibold tracking-tight text-black",
+  titleDefault: "mb-3 text-2xl font-semibold tracking-tight text-black",
 } as const;
 
 const AVATAR_STYLES = {

--- a/src/components/portal/project/ProjectBoardContent.tsx
+++ b/src/components/portal/project/ProjectBoardContent.tsx
@@ -11,6 +11,7 @@ import { EditTaskModal } from './tasks/EditTaskModal';
 import { TaskActionsMenu } from './tasks/TaskActionsMenu';
 import { CreateTaskInput, UpdateTaskInput } from '@/lib/types/tasks';
 import { TaskStatus, TaskWithAssignments } from '@/lib/types/database';
+import { getProfileDisplayName } from '@/lib/utils/profileName';
 
 const BUTTON_STYLES = {
   addTask: "mt-1 flex w-full items-center justify-center rounded-xl border border-dashed border-black/15 bg-white/60 px-3 py-2 text-[11px] md:text-xs font-medium text-black/70 transition-all duration-150 ease-out hover:bg-white hover:border-black/30 hover:-translate-y-0.5",
@@ -190,7 +191,7 @@ export default function ProjectBoardContent({ projectId, currentUserId }: Projec
     .filter((m) => m.user.id !== currentUserId)
     .map((m) => ({
       id: m.user.id,
-      display_name: m.user.display_name,
+      display_name: getProfileDisplayName(m.user),
     }));
 
   // handle task creation
@@ -308,6 +309,7 @@ export default function ProjectBoardContent({ projectId, currentUserId }: Projec
           <h1 className="text-2xl md:text-3xl font-semibold tracking-tight text-black">
             Tasks
           </h1>
+          <p className="text-sm font-semibold text-black">Tasks</p>
           <p className="text-[11px] md:text-xs text-black/50">{today}</p>
         </div>
         <div className="flex items-center gap-4">

--- a/src/components/portal/project/ProjectListContent.tsx
+++ b/src/components/portal/project/ProjectListContent.tsx
@@ -11,6 +11,7 @@ import { EditTaskModal } from './tasks/EditTaskModal';
 import { TaskActionsMenu } from './tasks/TaskActionsMenu';
 import { CreateTaskInput, UpdateTaskInput } from '@/lib/types/tasks';
 import { TaskStatus, TaskWithAssignments } from '@/lib/types/database';
+import { getProfileDisplayName } from '@/lib/utils/profileName';
 
 type StatusId = "todo" | "in_progress" | "in_review" | "done";
 type Priority = "low" | "medium" | "high" | "urgent";
@@ -78,17 +79,6 @@ const STATUS_META: Record<StatusId, { label: string; bandBg: string; textColor: 
 // helper to map database task status to ui status id
 function mapTaskStatusToStatusId(status: TaskStatus): StatusId {
   return status as StatusId;
-}
-
-// helper to get assignee initials from display name
-function getInitials(displayName: string | undefined | null): string {
-  if (!displayName) return "?";
-  return displayName
-    .split(' ')
-    .map(word => word[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
 }
 
 function AssigneeGroup({ assignees }: { assignees: Assignee[] }) {
@@ -319,7 +309,7 @@ export default function ProjectListContent({ projectId, currentUserId }: Project
     .filter((m) => m.user.id !== currentUserId)
     .map((m) => ({
       id: m.user.id,
-      display_name: m.user.display_name,
+      display_name: getProfileDisplayName(m.user),
     }));
 
   // handle task creation

--- a/src/lib/hooks/useInviteMembers.ts
+++ b/src/lib/hooks/useInviteMembers.ts
@@ -118,7 +118,7 @@ export function useInviteMembers(
   const filteredMembers = availableMembers.filter(member => {
     const query = searchQuery.toLowerCase();
     return (
-      member.display_name.toLowerCase().includes(query) ||
+      (member.display_name?.toLowerCase().includes(query) ?? false) ||
       member.email.toLowerCase().includes(query)
     );
   });

--- a/src/lib/services/inviteService.ts
+++ b/src/lib/services/inviteService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../supabase/client';
 import { Profiles } from '../types/database';
+import { getProfileDisplayName } from '../utils/profileName';
 import { TaskOperationResult } from '../types/tasks';
 
 export type AvailableMember = Profiles;
@@ -21,7 +22,7 @@ export async function getAvailableMembers(
 
   let query = supabase
     .from('profiles')
-    .select('id, email, display_name, created_at');
+    .select('id, email, first_name, last_name, created_at');
 
   if (existingUserIds.length > 0) {
     query = query.not('id', 'in', `(${existingUserIds.join(',')})`);
@@ -34,7 +35,12 @@ export async function getAvailableMembers(
     return { data: null, error: error.message, success: false };
   }
 
-  return { data: data as AvailableMember[], error: null, success: true };
+  const membersWithNames = (data || []).map((member) => ({
+    ...member,
+    display_name: getProfileDisplayName(member),
+  }));
+
+  return { data: membersWithNames as AvailableMember[], error: null, success: true };
 }
 
 /**

--- a/src/lib/services/projectMemberService.ts
+++ b/src/lib/services/projectMemberService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../supabase/client';
 import { ProjectMember, Profiles, Role } from '../types/database';
+import { getProfileDisplayName } from '../utils/profileName';
 import { TaskOperationResult } from '../types/tasks';
 
 export interface ProjectMemberWithProfile extends ProjectMember {
@@ -17,7 +18,8 @@ export async function getProjectMembers(
       user:profiles!project_members_user_id_fkey (
         id,
         email,
-        display_name,
+        first_name,
+        last_name,
         created_at
       ),
       rbac_role:roles!project_members_rbac_role_id_fkey (
@@ -40,7 +42,7 @@ export async function getProjectMembers(
     rbac_role: member.rbac_role as Role | undefined,
     user: {
       ...member.user,
-      display_name: member.user.display_name || member.user.email?.split('@')[0] || 'Unknown',
+      display_name: getProfileDisplayName(member.user),
     },
   }));
 

--- a/src/lib/services/taskService.ts
+++ b/src/lib/services/taskService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../supabase/client';
 import { Task, TaskAssignment, TaskWithAssignments } from '../types/database';
+import { getProfileDisplayName } from '../utils/profileName';
 import {
   CreateTaskInput,
   AssignTaskInput,
@@ -95,12 +96,14 @@ export async function getTasksWithAssignments(
         assigned_by,
         assignee:profiles!task_assignments_user_id_fkey (
           id,
-          display_name,
+          first_name,
+          last_name,
           email
         ),
         assigned_by_profile:profiles!task_assignments_assigned_by_fkey (
           id,
-          display_name,
+          first_name,
+          last_name,
           email
         )
       )
@@ -113,7 +116,24 @@ export async function getTasksWithAssignments(
     return { data: null, error: error.message, success: false };
   }
 
-  return { data: data as TaskWithAssignments[], error: null, success: true };
+  const tasksWithNames = (data || []).map((task) => ({
+    ...task,
+    assignments: (task.assignments || []).map((assignment) => ({
+      ...assignment,
+      assignee: {
+        ...assignment.assignee,
+        display_name: getProfileDisplayName(assignment.assignee),
+      },
+      assigned_by_profile: assignment.assigned_by_profile
+        ? {
+          ...assignment.assigned_by_profile,
+          display_name: getProfileDisplayName(assignment.assigned_by_profile),
+        }
+        : null,
+    })),
+  }));
+
+  return { data: tasksWithNames as TaskWithAssignments[], error: null, success: true };
 }
 
 /**

--- a/src/lib/supabase/profileService.ts
+++ b/src/lib/supabase/profileService.ts
@@ -3,6 +3,9 @@ import { supabase } from './client';
 export interface Profile {
   id: string;
   email: string;
+  first_name: string | null;
+  last_name: string | null;
+  display_name?: string | null;
   created_at: string;
 }
 

--- a/src/lib/supabase/projectService.ts
+++ b/src/lib/supabase/projectService.ts
@@ -1,6 +1,14 @@
 import { supabase } from './client';
 import { Project } from '@/types/project';
 
+export interface ProjectSettingsUpdate {
+  projectName?: string;
+  githubUrl?: string | null;
+  figmaUrl?: string | null;
+  notionUrl?: string | null;
+  logoUrl?: string | null;
+}
+
 export async function getProjectsByYear(year: string): Promise<Project[]> {
     const { data, error } = await supabase
         .from('projects')
@@ -84,3 +92,48 @@ export async function createProject(project: Omit<Project, 'id'>): Promise<Proje
     return data as Project;
 }
 
+export async function updateProjectSettings(
+  projectId: string,
+  updates: ProjectSettingsUpdate
+): Promise<Project | null> {
+  const { data, error } = await supabase
+    .from('projects')
+    .update(updates)
+    .eq('id', projectId)
+    .select('*')
+    .single();
+
+  if (error || !data) {
+    console.error('Error updating project settings:', error);
+    return null;
+  }
+
+  return data as Project;
+}
+
+export async function uploadProjectLogo(
+  projectId: string,
+  file: File,
+  bucketName = 'project_logos'
+): Promise<string | null> {
+  const fileExt = file.name.split('.').pop() || 'png';
+  const fileName = `logo-${Date.now()}.${fileExt}`;
+  const filePath = `${projectId}/${fileName}`;
+
+  const { error: uploadError } = await supabase
+    .storage
+    .from(bucketName)
+    .upload(filePath, file, { cacheControl: '3600', upsert: true });
+
+  if (uploadError) {
+    console.error('Error uploading project logo:', uploadError);
+    return null;
+  }
+
+  const { data: publicUrl } = supabase
+    .storage
+    .from(bucketName)
+    .getPublicUrl(filePath);
+
+  return publicUrl?.publicUrl || null;
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -42,7 +42,9 @@ export interface Profiles {
   id: string;
   created_at: string;
   email: string;
-  display_name: string;
+  first_name: string | null;
+  last_name: string | null;
+  display_name?: string | null;
 }
 
 export interface ProjectMember {

--- a/src/lib/utils/profileName.ts
+++ b/src/lib/utils/profileName.ts
@@ -1,0 +1,17 @@
+import { Profiles } from '../types/database';
+
+type ProfileNameSource = Pick<Profiles, 'email' | 'first_name' | 'last_name'>;
+
+export function getProfileDisplayName(profile?: ProfileNameSource | null): string {
+  if (!profile) return 'Unknown';
+  const fullName = [profile.first_name, profile.last_name].filter(Boolean).join(' ').trim();
+  if (fullName) return fullName;
+  return profile.email?.split('@')[0] || 'Unknown';
+}
+
+export function getProfileFirstName(profile?: ProfileNameSource | null): string {
+  if (!profile) return 'Unknown';
+  const firstName = profile.first_name;
+  if (firstName) return firstName;
+  return profile.email?.split('@')[0] || 'Unknown';
+}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -7,7 +7,10 @@ export interface Project {
     projectDescription: string;
     projectManagers: string[] | null;
     projectMembers: string[] | null;
-    logoUrl?: string;
+    logoUrl?: string | null;
+    githubUrl?: string | null;
+    figmaUrl?: string | null;
+    notionUrl?: string | null;
     prototypeUrl?: string;
     demoDayUrl?: string;
     instaPostUrl?: string;


### PR DESCRIPTION
## Summary
This PR adds project logo uploading by Supabase Storage buckets, a new settings page for managing project links and logo, and some UI improvements

## Changes

- Added `uploadProjectLogo` to `projectService` to support image uploading. The bucket in Supabase storage is called `project_logos`
- New Settings page with logo upload and editable GitHub, Figma, and Notion URL fields
- Converted `(with-sidebar)/[projectId]/layout.tsx` to a server component to fetch projectName and logoUrl on first render _(This fixed the client-side flicker where the sidebar would briefly show a blank project name while waiting for a useEffect fetch to complete)_
- Changed profile name display to use `getProfileFirstName` and `getProfileDisplayName` to both get first name or full name.
- Fixed sign up page to insert first and last name from user inputted field into profiles table in database