### PR TITLE
feat(internal): finance funding requests page

### DIFF
--- a/src/app/(portal)/portal/internal/finance/page.tsx
+++ b/src/app/(portal)/portal/internal/finance/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import { getFinanceRequests } from '@/lib/supabase/financeRequestService';
+import { FinanceRequest } from '@/types/financeRequest';
+import FinanceRequestBoard from '@/components/portal/internal/finance/FinanceRequestBoard';
+import FinanceRequestPanel from '@/components/portal/internal/finance/FinanceRequestPanel';
+import { getCurrentQuarter, getAllQuarters } from '@/lib/utils/quarterService';
+import { useIsFinanceApprover } from '@/lib/hooks/useIsFinanceApprover';
+
+export default function FinancePage() {
+  const [requests, setRequests] = useState<FinanceRequest[]>([]);
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const [editingRequest, setEditingRequest] = useState<FinanceRequest | undefined>();
+  const [selectedQuarter, setSelectedQuarter] = useState(getCurrentQuarter());
+  const quarters = useMemo(() => getAllQuarters('2026-03-21'), []);
+  const { isApprover } = useIsFinanceApprover();
+
+  const loadRequests = async () => {
+    try {
+      const data = await getFinanceRequests();
+      setRequests(data);
+    } catch (err) {
+      console.error('Failed to load finance requests:', err);
+    }
+  };
+
+  useEffect(() => {
+    loadRequests();
+  }, []);
+
+  const handleOpenCreate = () => {
+    setEditingRequest(undefined);
+    setIsPanelOpen(true);
+  };
+
+  const handleOpenEdit = (request: FinanceRequest) => {
+    setEditingRequest(request);
+    setIsPanelOpen(true);
+  };
+
+  const handleRequestSubmit = () => {
+    loadRequests();
+    setIsPanelOpen(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Finance</h1>
+        <div className="flex items-center gap-2">
+          <select
+            value={selectedQuarter}
+            onChange={(e) => setSelectedQuarter(e.target.value)}
+            className="text-sm border border-[#D4D7E5] rounded-lg px-3 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-300"
+          >
+            {quarters.map(q => <option key={q} value={q}>{q}</option>)}
+          </select>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-[#D4D7E5] bg-white shadow-lg p-5 text-sm text-gray-600 leading-relaxed space-y-3">
+        <p>
+          Use this form to request funding to be made by 🆑 Finance!
+        </p>
+        <p>
+          📣 <strong>IMPORTANT — PLEASE READ:</strong> Please request funding <strong>AT LEAST 4 WEEKS in advance</strong> (the earlier the better!) as funding request forms MANDATE THIS! We would like to get funding for as many things as possible rather than take it out of our account ❤️
+        </p>
+        <p>
+          <strong>Things we CAN get money for:</strong>
+        </p>
+        <ul className="list-disc list-inside space-y-0.5 pl-2">
+          <li>food — request 4 weeks ahead</li>
+          <li>supplies for socials — request 4 weeks ahead</li>
+          <li>apple developer licenses, web app domains, hardware for projects — request 4 weeks ahead (or better yet at the beginning of the quarter ⇒ the app closes end of WEEK 5) — PROJECT DIRECTORS</li>
+          <li>retreat — request 4 weeks ahead — MARKETING DIRECTOR</li>
+        </ul>
+        <p>
+          Please message Aanika and/or Siri as soon as you finish filling out a request below! They will let you know when your request has been processed.
+        </p>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          onClick={handleOpenCreate}
+          className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded-xl shadow-lg shadow-blue-200 transition-all transform hover:-translate-y-0.5 active:scale-95"
+        >
+          New +
+        </button>
+      </div>
+
+      <FinanceRequestBoard
+        requests={requests}
+        selectedQuarter={selectedQuarter}
+        onEditRequest={handleOpenEdit}
+        onRefresh={loadRequests}
+        isApprover={isApprover}
+      />
+
+      <FinanceRequestPanel
+        isOpen={isPanelOpen}
+        onClose={() => setIsPanelOpen(false)}
+        onSubmit={handleRequestSubmit}
+        editingRequest={editingRequest}
+      />
+    </div>
+  );
+}

--- a/src/components/portal/internal/InternalSidebar.tsx
+++ b/src/components/portal/internal/InternalSidebar.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { RxDashboard, RxPencil2 } from "react-icons/rx";
+import { BsCashCoin } from "react-icons/bs";
 
 const NAV_STYLES = {
   base: "flex items-center gap-3 rounded-xl px-3 py-3 text-l transition-colors duration-150",
@@ -13,6 +14,7 @@ const NAV_STYLES = {
 const COMMITTEE_ITEMS = [
   { id: "projects", label: "Projects", href: "/portal/internal/projects", icon: RxDashboard },
   { id: "design", label: "Design", href: "/portal/internal/design", icon: RxPencil2 },
+  { id: "finance", label: "Finance", href: "/portal/internal/finance", icon: BsCashCoin },
 ] as const;
 
 export default function InternalSidebar({ className = "" }: { className?: string }) {

--- a/src/components/portal/internal/finance/FinanceRequestBoard.tsx
+++ b/src/components/portal/internal/finance/FinanceRequestBoard.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useMemo } from 'react';
+import { FinanceRequest, FinanceRequestStatus, STATUS_ORDER } from '@/types/financeRequest';
+import FinanceRequestCard from './FinanceRequestCard';
+
+const COLUMN_STYLES: Record<FinanceRequestStatus, { bg: string; text: string }> = {
+  'Applied': {
+    bg: 'bg-[#FFF4E5]',
+    text: 'text-gray-700',
+  },
+  'Not yet processed': {
+    bg: 'bg-[#FDF2F1]',
+    text: 'text-gray-700',
+  },
+  'Processed!': {
+    bg: 'bg-[#F1F6F1]',
+    text: 'text-gray-700',
+  },
+};
+
+interface FinanceRequestBoardProps {
+  requests: FinanceRequest[];
+  selectedQuarter: string;
+  onEditRequest: (request: FinanceRequest) => void;
+  onRefresh: () => void;
+  isApprover: boolean;
+}
+
+export default function FinanceRequestBoard({ requests, selectedQuarter, onEditRequest, onRefresh, isApprover }: FinanceRequestBoardProps) {
+  const filteredRequests = useMemo(
+    () => requests.filter(r => r.quarter === selectedQuarter),
+    [requests, selectedQuarter]
+  );
+
+  const grouped = useMemo(() => {
+    const groups: Record<FinanceRequestStatus, FinanceRequest[]> = {
+      'Applied': [],
+      'Not yet processed': [],
+      'Processed!': [],
+    };
+    filteredRequests.forEach((r) => {
+      if (groups[r.status]) {
+        groups[r.status].push(r);
+      }
+    });
+    return groups;
+  }, [filteredRequests]);
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-start">
+      {STATUS_ORDER.map((status) => (
+        <div
+          key={status}
+          className={`rounded-2xl ${COLUMN_STYLES[status].bg} flex flex-col p-4 border border-[#D4D7E5]/50 shadow-sm min-h-[400px]`}
+        >
+          <div className="flex items-center gap-2 mb-4 px-1">
+            <h3 className={`font-bold text-sm ${COLUMN_STYLES[status].text} flex items-center gap-2`}>
+              {status}
+              <span className="text-gray-400 font-medium ml-1">
+                {grouped[status].length}
+              </span>
+            </h3>
+          </div>
+
+          <div className="space-y-4 flex-1">
+            {grouped[status].map((request) => (
+              <FinanceRequestCard
+                key={request.id}
+                request={request}
+                onEdit={() => onEditRequest(request)}
+                onRefresh={onRefresh}
+                isApprover={isApprover}
+              />
+            ))}
+            {grouped[status].length === 0 && (
+              <div className="flex items-center justify-center h-32 text-gray-300 text-xs italic">
+                No requests found
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/portal/internal/finance/FinanceRequestCard.tsx
+++ b/src/components/portal/internal/finance/FinanceRequestCard.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import {
+  FinanceRequest,
+  FinanceRequestStatus,
+  COMMITTEE_COLORS,
+  COMMITTEE_TEXT,
+  EXPENSE_CATEGORY_COLORS,
+  EXPENSE_CATEGORY_TEXT,
+} from '@/types/financeRequest';
+import { updateFinanceRequest } from '@/lib/supabase/financeRequestService';
+import { getProfileById } from '@/lib/supabase/profileService';
+import { BsThreeDots } from 'react-icons/bs';
+
+const STATUS_LABELS: Record<FinanceRequestStatus, string> = {
+  'Applied': 'Applied',
+  'Not yet processed': 'Pending',
+  'Processed!': 'Processed',
+};
+
+const STATUS_ACTIVE_CLASS: Record<FinanceRequestStatus, string> = {
+  'Applied': 'bg-white text-orange-500 shadow-sm',
+  'Not yet processed': 'bg-white text-red-500 shadow-sm',
+  'Processed!': 'bg-white text-green-500 shadow-sm',
+};
+
+const AVATAR_COLORS = [
+  'bg-pink-500',
+  'bg-blue-500',
+  'bg-green-500',
+  'bg-purple-500',
+  'bg-indigo-500',
+  'bg-rose-500',
+  'bg-amber-500',
+];
+
+function getAvatarColor(name: string) {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}
+
+const STATUS_BADGE_CLASS: Record<FinanceRequestStatus, string> = {
+  'Applied': 'bg-orange-100 text-orange-700',
+  'Not yet processed': 'bg-red-100 text-red-700',
+  'Processed!': 'bg-green-100 text-green-700',
+};
+
+interface FinanceRequestCardProps {
+  request: FinanceRequest;
+  onEdit: () => void;
+  onRefresh: () => void;
+  isApprover: boolean;
+}
+
+export default function FinanceRequestCard({ request, onEdit, onRefresh, isApprover }: FinanceRequestCardProps) {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [creatorProfile, setCreatorProfile] = useState<{ name: string; id: string } | null>(null);
+
+  useEffect(() => {
+    if (!request.created_by) {
+      setCreatorProfile({ name: 'Unknown', id: '' });
+      return;
+    }
+    getProfileById(request.created_by).then((profile) => {
+      if (profile) {
+        setCreatorProfile({
+          name: profile.display_name || [profile.first_name, profile.last_name].filter(Boolean).join(' ') || 'Unknown',
+          id: profile.id,
+        });
+      } else {
+        setCreatorProfile({ name: 'Unknown', id: '' });
+      }
+    });
+  }, [request.created_by]);
+
+  const handleStatusChange = async (newStatus: FinanceRequestStatus) => {
+    if (newStatus === request.status) return;
+    setIsUpdating(true);
+    try {
+      await updateFinanceRequest(request.id, { status: newStatus });
+      onRefresh();
+    } catch (err) {
+      console.error('Failed to update status:', err);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const formattedDate = new Date(request.created_at).toLocaleString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+
+  const creatorInitial = creatorProfile?.name.charAt(0).toUpperCase() || '?';
+  const avatarBg = creatorProfile ? getAvatarColor(creatorProfile.name) : 'bg-gray-400';
+
+  return (
+    <div className="bg-white p-4 rounded-2xl shadow-sm border border-[#D4D7E5]/50 space-y-3 hover:shadow-md transition-shadow relative group">
+      {isApprover && (
+        <button
+          onClick={onEdit}
+          className="absolute top-3 right-3 p-1 rounded-lg hover:bg-gray-100 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <BsThreeDots size={16} />
+        </button>
+      )}
+
+      <div className="font-bold text-gray-800 leading-tight pr-6 text-[15px]">
+        {request.name}
+      </div>
+
+      <div className="flex flex-col gap-1.5 pt-0.5">
+        <div className="flex">
+          <span
+            className="text-[10px] font-bold px-2 py-0.5 rounded-md uppercase tracking-wide"
+            style={{
+              backgroundColor: EXPENSE_CATEGORY_COLORS[request.expense_category] || '#f3f4f6',
+              color: EXPENSE_CATEGORY_TEXT[request.expense_category] || '#374151',
+            }}
+          >
+            {request.expense_category}
+          </span>
+        </div>
+        <div className="flex">
+          <span
+            className="text-[10px] font-bold px-2 py-0.5 rounded-md uppercase tracking-wide"
+            style={{
+              backgroundColor: COMMITTEE_COLORS[request.committee] || '#f3f4f6',
+              color: COMMITTEE_TEXT[request.committee] || '#374151',
+            }}
+          >
+            {request.committee}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 pt-1">
+        <div className={`w-5 h-5 rounded-full ${avatarBg} flex items-center justify-center text-[10px] font-bold text-white shadow-sm`}>
+          {creatorInitial}
+        </div>
+        <span className="text-[13px] text-gray-700 font-medium">{creatorProfile?.name}</span>
+      </div>
+
+      <div className="text-[12px] text-gray-500 font-medium">
+        {formattedDate}
+      </div>
+
+      {isApprover ? (
+        <div className={`flex p-0.5 bg-gray-100/80 rounded-xl mt-2 ${isUpdating ? 'opacity-50 pointer-events-none' : ''}`}>
+          {(Object.keys(STATUS_LABELS) as FinanceRequestStatus[]).map((status) => (
+            <button
+              key={status}
+              onClick={() => handleStatusChange(status)}
+              className={`flex-1 text-[10px] font-bold py-1.5 px-1 rounded-lg transition-all ${
+                request.status === status
+                  ? STATUS_ACTIVE_CLASS[status]
+                  : 'text-gray-400 hover:text-gray-500'
+              }`}
+            >
+              {STATUS_LABELS[status]}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="flex pt-1">
+          <span className={`text-[10px] font-bold px-2 py-1 rounded-md ${STATUS_BADGE_CLASS[request.status]}`}>
+            {STATUS_LABELS[request.status]}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/portal/internal/finance/FinanceRequestPanel.tsx
+++ b/src/components/portal/internal/finance/FinanceRequestPanel.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { createFinanceRequest, updateFinanceRequest } from '@/lib/supabase/financeRequestService';
+import {
+  Committee,
+  ExpenseCategory,
+  FinanceRequest,
+} from '@/types/financeRequest';
+import { getCurrentQuarter, getAllQuarters } from '@/lib/utils/quarterService';
+import { getCurrentUserId } from '@/lib/supabase/profileService';
+import { IoClose } from 'react-icons/io5';
+
+const COMMITTEES: Committee[] = ['Marketing', 'Projects', 'Tech', 'Finance'];
+const EXPENSE_CATEGORIES: ExpenseCategory[] = [
+  'Food',
+  'Supplies',
+  'Project Developer Resources',
+  'Retreat',
+  'Other',
+];
+const QUARTERS = getAllQuarters('2026-03-21');
+
+interface FinanceRequestPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  editingRequest?: FinanceRequest;
+}
+
+export default function FinanceRequestPanel({ isOpen, onClose, onSubmit, editingRequest }: FinanceRequestPanelProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setError(null);
+    }
+  }, [isOpen, editingRequest]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const formData = new FormData(e.currentTarget);
+
+    try {
+      const userId = await getCurrentUserId().catch(() => null);
+
+      const estimatedRaw = formData.get('estimated_amount') as string;
+      const exactRaw = formData.get('exact_amount') as string;
+      const peopleRaw = formData.get('how_many_people') as string;
+
+      const requestData: any = {
+        name: formData.get('name') as string,
+        event: (formData.get('event') as string) || null,
+        expense_category: formData.get('expense_category') as ExpenseCategory,
+        committee: formData.get('committee') as Committee,
+        estimated_amount: estimatedRaw ? Number(estimatedRaw) : null,
+        exact_amount: exactRaw ? Number(exactRaw) : null,
+        receipt: (formData.get('receipt') as string) || null,
+        how_many_people: peopleRaw ? Number(peopleRaw) : null,
+        what_will_it_cover: (formData.get('what_will_it_cover') as string) || null,
+        description: (formData.get('description') as string) || '',
+        outcomes: (formData.get('outcomes') as string) || '',
+        cost_documentation: (formData.get('cost_documentation') as string) || '',
+        event_location: (formData.get('event_location') as string) || null,
+        event_date: formData.get('event_date') ? new Date(formData.get('event_date') as string).toISOString() : null,
+        due_date: (formData.get('due_date') as string) || null,
+        quarter: formData.get('quarter') as string,
+        notes: (formData.get('notes') as string) || null,
+        created_by: userId,
+      };
+
+      if (editingRequest) {
+        await updateFinanceRequest(editingRequest.id, requestData);
+      } else {
+        await createFinanceRequest(requestData);
+      }
+
+      formRef.current?.reset();
+      onSubmit();
+    } catch (err: any) {
+      console.error('Submission error:', err);
+      setError(err?.message ?? 'Failed to save request. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex">
+      <div
+        className="flex-1 bg-black/30 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <div className="w-full max-w-xl bg-white shadow-2xl flex flex-col border-l border-gray-100 h-full">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 bg-gray-50 flex-shrink-0">
+          <h2 className="text-xl font-bold text-gray-900">
+            {editingRequest ? 'Edit Funding Request' : 'New Funding Request'}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-gray-200 transition-colors text-gray-500"
+          >
+            <IoClose size={24} />
+          </button>
+        </div>
+
+        <form ref={formRef} onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-6 space-y-5">
+          {error && (
+            <div className="p-4 bg-red-50 text-red-700 border border-red-200 rounded-xl text-sm font-medium">
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-col space-y-1">
+            <label className="text-xs font-bold text-gray-500 uppercase">
+              Request Name <span className="text-red-400">*</span>
+            </label>
+            <input
+              required
+              name="name"
+              defaultValue={editingRequest?.name}
+              placeholder="e.g. Dominos for Demo Day"
+              className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label className="text-xs font-bold text-gray-500 uppercase">Event</label>
+            <input
+              name="event"
+              defaultValue={editingRequest?.event ?? ''}
+              placeholder="e.g. Demo Day F24"
+              className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-gray-500 uppercase">
+                Category <span className="text-red-400">*</span>
+              </label>
+              <select
+                required
+                name="expense_category"
+                defaultValue={editingRequest?.expense_category ?? ''}
+                className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none cursor-pointer"
+              >
+                <option value="">Select</option>
+                {EXPENSE_CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-gray-500 uppercase">
+                Committee <span className="text-red-400">*</span>
+              </label>
+              <select
+                required
+                name="committee"
+                defaultValue={editingRequest?.committee ?? ''}
+                className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none cursor-pointer"
+              >
+                <option value="">Select</option>
+                {COMMITTEES.map(c => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-gray-500 uppercase">Estimated Amount ($)</label>
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                name="estimated_amount"
+                defaultValue={editingRequest?.estimated_amount ?? ''}
+                placeholder="e.g. 162"
+                className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-gray-500 uppercase">Exact Amount ($)</label>
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                name="exact_amount"
+                defaultValue={editingRequest?.exact_amount ?? ''}
+                placeholder="e.g. 161.97"
+                className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-gray-500 uppercase">Receipt</label>
+              <input
+                type="url"
+                name="receipt"
+                defaultValue={editingRequest?.receipt ?? ''}
+                placeholder="https://docs.google.com/..."
+                className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-gray-500 uppercase">How Many People</label>
+              <input
+                type="number"
+                min="0"
+                name="how_many_people"
+                defaultValue={editingRequest?.how_many_people ?? ''}
+                placeholder="e.g. 65"
+                className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label className="text-xs font-bold text-gray-500 uppercase">What Will It Cover?</label>
+            <textarea
+              name="what_will_it_cover"
+              rows={2}
+              defaultValue={editingRequest?.what_will_it_cover ?? ''}
+              placeholder="e.g. 8 Large Dominos pizzas (4 cheese, 4 pepperoni) — 64 slices total"
+              className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            />
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label className="text-xs font-bold text-gray-500 uppercase">
+              Description of Program
+            </label>
+            <textarea
+              name="description"
+              rows={3}
+              defaultValue={editingRequest?.description}
+              placeholder="Brief but detailed summary of your program. Include date, location, & time."
+              className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            />
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label className="text-xs font-bold text-gray-500 uppercase">
+              Program Outcomes
+            </label>
+            <textarea
+              name="outcomes"
+              rows={3}
+              defaultValue={editingRequest?.outcomes}
+              placeholder="What do you hope to accomplish? Concrete ways you will get there."
+              className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            />
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label className="text-xs font-bold text-gray-500 uppercase">
+              Cost Documentation
+            </label>
+            <input
+              name="cost_documentation"
+              defaultValue={editingRequest?.cost_documentation}
+              placeholder="Link to budget spreadsheet (items, qty, unit/total price, quotes)"
+              className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-gray-500 uppercase">Event Location</label>
+              <input
+                name="event_location"
+                defaultValue={editingRequest?.event_location ?? ''}
+                placeholder="e.g. Boelter Hall"
+                className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-gray-500 uppercase">Event Date</label>
+              <input
+                type="datetime-local"
+                name="event_date"
+                defaultValue={editingRequest?.event_date ? new Date(editingRequest.event_date).toISOString().slice(0, 16) : ''}
+                className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-blue-600 uppercase">
+                Funds Needed By
+              </label>
+              <input
+                type="date"
+                name="due_date"
+                defaultValue={editingRequest?.due_date ?? ''}
+                className="px-4 py-3 bg-blue-50 border border-blue-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="flex flex-col space-y-1">
+              <label className="text-xs font-bold text-gray-500 uppercase">
+                Quarter <span className="text-red-400">*</span>
+              </label>
+              <select
+                required
+                name="quarter"
+                defaultValue={editingRequest?.quarter ?? getCurrentQuarter()}
+                className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 appearance-none cursor-pointer"
+              >
+                {QUARTERS.map(q => <option key={q} value={q}>{q}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div className="flex flex-col space-y-1">
+            <label className="text-xs font-bold text-gray-500 uppercase">Other Notes</label>
+            <textarea
+              name="notes"
+              rows={2}
+              defaultValue={editingRequest?.notes ?? ''}
+              placeholder="Additional context..."
+              className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            />
+          </div>
+
+          <div className="pt-2">
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-4 rounded-xl shadow-lg shadow-blue-200 transition-all transform hover:-translate-y-0.5 disabled:opacity-50 flex items-center justify-center gap-2"
+            >
+              {loading ? 'Saving...' : editingRequest ? 'Save Changes' : 'Create Request'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/hooks/useIsFinanceApprover.ts
+++ b/src/lib/hooks/useIsFinanceApprover.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabase/client';
+
+const APPROVER_ROLES = ['director', 'president', 'board - finance'];
+
+/**
+ * Returns true when the current user has an internal role allowed to
+ * approve / process finance funding requests.
+ */
+export function useIsFinanceApprover() {
+  const [isApprover, setIsApprover] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function check() {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        if (!cancelled) {
+          setIsApprover(false);
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      const { data } = await supabase
+        .from('user_context_roles')
+        .select('context, roles!inner(name)')
+        .eq('user_id', user.id);
+
+      const allowed = (data || []).some((row) => {
+        if (row.context !== 'internal') return false;
+        const name = (row.roles as unknown as { name: string })?.name;
+        return APPROVER_ROLES.includes(name);
+      });
+
+      if (!cancelled) {
+        setIsApprover(allowed);
+        setIsLoading(false);
+      }
+    }
+
+    check();
+    return () => { cancelled = true; };
+  }, []);
+
+  return { isApprover, isLoading };
+}

--- a/src/lib/supabase/financeRequestService.ts
+++ b/src/lib/supabase/financeRequestService.ts
@@ -1,0 +1,50 @@
+import { createClient } from './client';
+import { FinanceRequest, CreateFinanceRequest } from '@/types/financeRequest';
+
+export async function createFinanceRequest(request: CreateFinanceRequest) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('finance_requests')
+    .insert([request])
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error creating finance request:', error);
+    throw error;
+  }
+  return data as FinanceRequest;
+}
+
+export async function getFinanceRequests() {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('finance_requests')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('Error fetching finance requests:', error);
+    throw error;
+  }
+  return data as FinanceRequest[];
+}
+
+export async function updateFinanceRequest(
+  id: string,
+  updates: Partial<FinanceRequest>
+) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('finance_requests')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error updating finance request:', error);
+    throw error;
+  }
+  return data as FinanceRequest;
+}

--- a/src/types/financeRequest.ts
+++ b/src/types/financeRequest.ts
@@ -1,0 +1,75 @@
+export type Committee = 'Marketing' | 'Projects' | 'Tech' | 'Finance';
+
+export type ExpenseCategory =
+  | 'Food'
+  | 'Supplies'
+  | 'Project Developer Resources'
+  | 'Retreat'
+  | 'Other';
+
+export type FinanceRequestStatus = 'Applied' | 'Not yet processed' | 'Processed!';
+
+export interface FinanceRequest {
+  id: string;
+  name: string;
+  event?: string | null;
+  expense_category: ExpenseCategory;
+  committee: Committee;
+  estimated_amount?: number | null;
+  exact_amount?: number | null;
+  receipt?: string | null;
+  how_many_people?: number | null;
+  what_will_it_cover?: string | null;
+  description: string;
+  outcomes: string;
+  cost_documentation: string;
+  event_date?: string | null;
+  event_location?: string | null;
+  due_date?: string | null;
+  quarter: string;
+  status: FinanceRequestStatus;
+  notes?: string | null;
+  created_by?: string | null;
+  created_at: string;
+}
+
+export interface CreateFinanceRequest
+  extends Omit<FinanceRequest, 'id' | 'created_at' | 'status'> {
+  status?: FinanceRequestStatus;
+}
+
+export const STATUS_ORDER: FinanceRequestStatus[] = [
+  'Applied',
+  'Not yet processed',
+  'Processed!',
+];
+
+export const EXPENSE_CATEGORY_COLORS: Record<string, string> = {
+  Food: '#FFE5D6',
+  Supplies: '#E5F0FF',
+  'Project Developer Resources': '#EFE5FF',
+  Retreat: '#E5F9E9',
+  Other: '#F3F4F6',
+};
+
+export const EXPENSE_CATEGORY_TEXT: Record<string, string> = {
+  Food: '#E07A3B',
+  Supplies: '#3F86FF',
+  'Project Developer Resources': '#7B5BD6',
+  Retreat: '#3BB273',
+  Other: '#374151',
+};
+
+export const COMMITTEE_COLORS: Record<string, string> = {
+  Marketing: '#FFE5E5',
+  Projects: '#E5F0FF',
+  Tech: '#E5F9E9',
+  Finance: '#FFF9E5',
+};
+
+export const COMMITTEE_TEXT: Record<string, string> = {
+  Marketing: '#FF4D4D',
+  Projects: '#3F86FF',
+  Tech: '#3BB273',
+  Finance: '#FFB800',
+};


### PR DESCRIPTION
## Summary
- Adds `/portal/internal/finance` — kanban board for funding requests with columns **Applied / Not yet processed / Processed!**, mirroring the design request layout (committee + expense category badges, creator avatar, quarter dropdown via existing `getAllQuarters`)
- Submission drawer covers every Notion field: name, event, category, committee, estimated/exact amount, receipt, how many people, what will it cover, description, outcomes, cost documentation, event location/date, funds needed by, quarter, notes
- Status changes are gated to internal `director` / `president` / `board - finance` roles. Non-approvers see a static status badge instead of the interactive tabs and the edit menu is hidden