### PR TITLE
tinyCL internal page

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "lint": "eslint ."
     },
     "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.90.1",
         "@types/fabric": "^5.3.6",

--- a/src/app/(portal)/portal/internal/tinycl/page.tsx
+++ b/src/app/(portal)/portal/internal/tinycl/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { getLinks, deleteLink, Link } from '@/lib/supabase/linksService';
+import { getLinks, deleteLink, updateLinkPositions, Link } from '@/lib/supabase/linksService';
 import LinkBoard from '@/components/portal/internal/tinycl/LinkBoard';
 import LinkPanel from '@/components/portal/internal/tinycl/LinkPanel';
 
@@ -52,6 +52,24 @@ export default function TinyCLPage() {
     setIsPanelOpen(false);
   };
 
+  const handleOrderChange = async (updatedLinks: Link[]) => {
+    // Optimistically update the UI
+    setLinks(updatedLinks);
+
+    try {
+      // Persist the new positions to Supabase
+      const positionUpdates = updatedLinks.map((link, index) => ({
+        id: link.id,
+        position: index
+      }));
+      await updateLinkPositions(positionUpdates);
+    } catch (err) {
+      console.error('Failed to save link order:', err);
+      // Revert if it fails
+      loadLinks();
+    }
+  };
+
   return (
     <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700">
       {/* Header row — matches Design/Projects page */}
@@ -73,6 +91,7 @@ export default function TinyCLPage() {
         onEditLink={handleEditLink}
         onDeleteLink={handleDeleteLink}
         onAddNew={handleAddNew}
+        onOrderChange={handleOrderChange}
       />
 
       {/* Slide-over panel for Create/Update actions */}

--- a/src/app/(portal)/portal/internal/tinycl/page.tsx
+++ b/src/app/(portal)/portal/internal/tinycl/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getLinks, deleteLink, Link } from '@/lib/supabase/linksService';
+import LinkBoard from '@/components/portal/internal/tinycl/LinkBoard';
+import LinkPanel from '@/components/portal/internal/tinycl/LinkPanel';
+
+export default function TinyCLPage() {
+  const [links, setLinks] = useState<Link[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const [editingLink, setEditingLink] = useState<Link | undefined>();
+
+  const loadLinks = async () => {
+    try {
+      setLoading(true);
+      const data = await getLinks();
+      setLinks(data);
+    } catch (err) {
+      console.error('Failed to load links:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadLinks();
+  }, []);
+
+  const handleAddNew = () => {
+    setEditingLink(undefined);
+    setIsPanelOpen(true);
+  };
+
+  const handleEditLink = (link: Link) => {
+    setEditingLink(link);
+    setIsPanelOpen(true);
+  };
+
+  const handleDeleteLink = async (id: string) => {
+    try {
+      await deleteLink(id);
+      await loadLinks();
+    } catch (err) {
+      console.error('Delete error:', err);
+      alert('Failed to delete link. Check if you have internal member permissions.');
+    }
+  };
+
+  const handleFormSubmit = () => {
+    loadLinks();
+    setIsPanelOpen(false);
+  };
+
+  return (
+    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700">
+      {/* Header row — matches Design/Projects page */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">TinyCL</h1>
+        <button
+          onClick={handleAddNew}
+          className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded-xl shadow-lg shadow-blue-200 transition-all transform hover:-translate-y-0.5 active:scale-95"
+        >
+          New +
+        </button>
+      </div>
+
+
+      {/* Board component containing the list and "Add New" trigger */}
+      <LinkBoard
+        links={links}
+        loading={loading}
+        onEditLink={handleEditLink}
+        onDeleteLink={handleDeleteLink}
+        onAddNew={handleAddNew}
+      />
+
+      {/* Slide-over panel for Create/Update actions */}
+      <LinkPanel
+        isOpen={isPanelOpen}
+        onClose={() => setIsPanelOpen(false)}
+        onSubmit={handleFormSubmit}
+        editingLink={editingLink}
+      />
+    </div>
+  );
+}

--- a/src/components/portal/internal/InternalSidebar.tsx
+++ b/src/components/portal/internal/InternalSidebar.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { RxDashboard, RxPencil2 } from "react-icons/rx";
+import { RxDashboard, RxPencil2, RxLink2 } from "react-icons/rx";
 
 const NAV_STYLES = {
   base: "flex items-center gap-3 rounded-xl px-3 py-3 text-l transition-colors duration-150",
@@ -13,6 +13,7 @@ const NAV_STYLES = {
 const COMMITTEE_ITEMS = [
   { id: "projects", label: "Projects", href: "/portal/internal/projects", icon: RxDashboard },
   { id: "design", label: "Design", href: "/portal/internal/design", icon: RxPencil2 },
+  { id: "tinycl", label: "TinyCL", href: "/portal/internal/tinycl", icon: RxLink2 },
 ] as const;
 
 export default function InternalSidebar({ className = "" }: { className?: string }) {

--- a/src/components/portal/internal/tinycl/LinkBoard.tsx
+++ b/src/components/portal/internal/tinycl/LinkBoard.tsx
@@ -2,6 +2,7 @@
 
 import { Link } from '@/lib/supabase/linksService';
 import LinkCard from './LinkCard';
+import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 
 interface LinkBoardProps {
   links: Link[];
@@ -9,6 +10,7 @@ interface LinkBoardProps {
   onEditLink: (link: Link) => void;
   onDeleteLink: (id: string) => void;
   onAddNew: () => void;
+  onOrderChange: (newLinks: Link[]) => void;
 }
 
 export default function LinkBoard({ 
@@ -16,24 +18,66 @@ export default function LinkBoard({
   loading, 
   onEditLink, 
   onDeleteLink, 
-  onAddNew 
+  onAddNew,
+  onOrderChange
 }: LinkBoardProps) {
+
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    if (result.destination.index === result.source.index) return;
+
+    const reorderedLinks = Array.from(links);
+    const [removed] = reorderedLinks.splice(result.source.index, 1);
+    reorderedLinks.splice(result.destination.index, 0, removed);
+
+    // Update positions based on new index
+    const updatedLinks = reorderedLinks.map((link, index) => ({
+      ...link,
+      position: index
+    }));
+
+    onOrderChange(updatedLinks);
+  };
+
   return (
-    <div className="flex flex-col gap-3 max-w-2xl mx-auto w-full pb-20">
+    <div className="max-w-2xl mx-auto w-full pb-20">
       {loading ? (
         <div className="text-center text-gray-500 py-8 text-sm">Loading links...</div>
       ) : (
-        <>
-          {links.map((link) => (
-            <LinkCard
-              key={link.id}
-              link={link}
-              onEdit={onEditLink}
-              onDelete={onDeleteLink}
-            />
-          ))}
-
-        </>
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <Droppable droppableId="links-list">
+            {(provided) => (
+              <div 
+                {...provided.droppableProps} 
+                ref={provided.innerRef}
+                className="flex flex-col gap-3"
+              >
+                {links.map((link, index) => (
+                  <Draggable key={link.id} draggableId={link.id} index={index}>
+                    {(provided, snapshot) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.draggableProps}
+                        style={{
+                          ...provided.draggableProps.style,
+                          opacity: snapshot.isDragging ? 0.8 : 1,
+                        }}
+                      >
+                        <LinkCard
+                          link={link}
+                          onEdit={onEditLink}
+                          onDelete={onDeleteLink}
+                          dragHandleProps={provided.dragHandleProps}
+                        />
+                      </div>
+                    )}
+                  </Draggable>
+                ))}
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
       )}
     </div>
   );

--- a/src/components/portal/internal/tinycl/LinkBoard.tsx
+++ b/src/components/portal/internal/tinycl/LinkBoard.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Link } from '@/lib/supabase/linksService';
+import LinkCard from './LinkCard';
+
+interface LinkBoardProps {
+  links: Link[];
+  loading: boolean;
+  onEditLink: (link: Link) => void;
+  onDeleteLink: (id: string) => void;
+  onAddNew: () => void;
+}
+
+export default function LinkBoard({ 
+  links, 
+  loading, 
+  onEditLink, 
+  onDeleteLink, 
+  onAddNew 
+}: LinkBoardProps) {
+  return (
+    <div className="flex flex-col gap-3 max-w-2xl mx-auto w-full pb-20">
+      {loading ? (
+        <div className="text-center text-gray-500 py-8 text-sm">Loading links...</div>
+      ) : (
+        <>
+          {links.map((link) => (
+            <LinkCard
+              key={link.id}
+              link={link}
+              onEdit={onEditLink}
+              onDelete={onDeleteLink}
+            />
+          ))}
+
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/portal/internal/tinycl/LinkCard.tsx
+++ b/src/components/portal/internal/tinycl/LinkCard.tsx
@@ -2,15 +2,16 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { Link } from '@/lib/supabase/linksService';
-import { RxDotsVertical } from "react-icons/rx";
+import { RxDotsVertical, RxDragHandleDots2 } from "react-icons/rx";
 
 interface LinkCardProps {
   link: Link;
   onEdit: (link: Link) => void;
   onDelete: (id: string) => void;
+  dragHandleProps?: any;
 }
 
-export default function LinkCard({ link, onEdit, onDelete }: LinkCardProps) {
+export default function LinkCard({ link, onEdit, onDelete, dragHandleProps }: LinkCardProps) {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -25,52 +26,62 @@ export default function LinkCard({ link, onEdit, onDelete }: LinkCardProps) {
   }, []);
 
   return (
-    <div className="relative w-full group">
-      <a
-        href={link.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block w-full px-8 py-5 bg-white border border-[#c8d0d8] rounded-md text-center text-lg font-medium text-[#1a1a1a] no-underline cursor-pointer transition-all hover:shadow-lg hover:-translate-y-px"
+    <div className="relative w-full group flex items-center gap-2">
+      {/* Drag Handle */}
+      <div 
+        {...dragHandleProps}
+        className="p-2 text-gray-300 hover:text-gray-500 cursor-grab active:cursor-grabbing transition-colors"
       >
-        {link.display_name}
-      </a>
-      
-      <div className="absolute right-3 top-1/2 -translate-y-1/2 z-10" ref={menuRef}>
-        <button 
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            setShowMenu(!showMenu);
-          }}
-          className="p-2 bg-transparent border-none cursor-pointer text-[#9ca3af] rounded-full flex items-center justify-center transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none"
-        >
-          <RxDotsVertical size={20} />
-        </button>
+        <RxDragHandleDots2 size={24} />
+      </div>
 
-        {showMenu && (
-          <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-xl z-[100] min-w-[120px] py-1 overflow-hidden animate-in fade-in zoom-in duration-100">
-            <button 
-              onClick={(e) => {
-                e.stopPropagation();
-                onEdit(link);
-                setShowMenu(false);
-              }}
-              className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-gray-700 cursor-pointer hover:bg-gray-50 transition-colors"
-            >
-              Edit
-            </button>
-            <button 
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(link.id);
-                setShowMenu(false);
-              }}
-              className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-red-600 cursor-pointer hover:bg-red-50 transition-colors"
-            >
-              Delete
-            </button>
-          </div>
-        )}
+      <div className="relative flex-1">
+        <a
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block w-full px-8 py-5 bg-white border border-[#c8d0d8] rounded-md text-center text-lg font-medium text-[#1a1a1a] no-underline cursor-pointer transition-all hover:shadow-lg hover:-translate-y-px"
+        >
+          {link.display_name}
+        </a>
+        
+        <div className="absolute right-3 top-1/2 -translate-y-1/2 z-10" ref={menuRef}>
+          <button 
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setShowMenu(!showMenu);
+            }}
+            className="p-2 bg-transparent border-none cursor-pointer text-[#9ca3af] rounded-full flex items-center justify-center transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none"
+          >
+            <RxDotsVertical size={20} />
+          </button>
+
+          {showMenu && (
+            <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-xl z-[100] min-w-[120px] py-1 overflow-hidden animate-in fade-in zoom-in duration-100">
+              <button 
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit(link);
+                  setShowMenu(false);
+                }}
+                className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-gray-700 cursor-pointer hover:bg-gray-50 transition-colors"
+              >
+                Edit
+              </button>
+              <button 
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(link.id);
+                  setShowMenu(false);
+                }}
+                className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-red-600 cursor-pointer hover:bg-red-50 transition-colors"
+              >
+                Delete
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/portal/internal/tinycl/LinkCard.tsx
+++ b/src/components/portal/internal/tinycl/LinkCard.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Link } from '@/lib/supabase/linksService';
+import { RxDotsVertical } from "react-icons/rx";
+
+interface LinkCardProps {
+  link: Link;
+  onEdit: (link: Link) => void;
+  onDelete: (id: string) => void;
+}
+
+export default function LinkCard({ link, onEdit, onDelete }: LinkCardProps) {
+  const [showMenu, setShowMenu] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setShowMenu(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="relative w-full group">
+      <a
+        href={link.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block w-full px-8 py-5 bg-white border border-[#c8d0d8] rounded-md text-center text-lg font-medium text-[#1a1a1a] no-underline cursor-pointer transition-all hover:shadow-lg hover:-translate-y-px"
+      >
+        {link.display_name}
+      </a>
+      
+      <div className="absolute right-3 top-1/2 -translate-y-1/2 z-10" ref={menuRef}>
+        <button 
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setShowMenu(!showMenu);
+          }}
+          className="p-2 bg-transparent border-none cursor-pointer text-[#9ca3af] rounded-full flex items-center justify-center transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none"
+        >
+          <RxDotsVertical size={20} />
+        </button>
+
+        {showMenu && (
+          <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-xl z-[100] min-w-[120px] py-1 overflow-hidden animate-in fade-in zoom-in duration-100">
+            <button 
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(link);
+                setShowMenu(false);
+              }}
+              className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-gray-700 cursor-pointer hover:bg-gray-50 transition-colors"
+            >
+              Edit
+            </button>
+            <button 
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(link.id);
+                setShowMenu(false);
+              }}
+              className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-red-600 cursor-pointer hover:bg-red-50 transition-colors"
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/internal/tinycl/LinkPanel.tsx
+++ b/src/components/portal/internal/tinycl/LinkPanel.tsx
@@ -44,7 +44,6 @@ export default function LinkPanel({ isOpen, onClose, onSubmit, editingLink }: Li
   const [displayName, setDisplayName] = useState('');
   const [url, setUrl] = useState('');
   const [redirectPath, setRedirectPath] = useState('');
-  const [slugEdited, setSlugEdited] = useState(false);
 
   // Validation state
   const [urlError, setUrlError] = useState('');
@@ -59,38 +58,37 @@ export default function LinkPanel({ isOpen, onClose, onSubmit, editingLink }: Li
         setDisplayName(editingLink.display_name);
         setUrl(editingLink.url);
         setRedirectPath(editingLink.redirect_path);
-        setSlugEdited(true);
       } else {
         setDisplayName('');
         setUrl('');
         setRedirectPath('');
-        setSlugEdited(false);
       }
     }
   }, [isOpen, editingLink]);
 
   useEffect(() => {
-    if (!slugEdited && !editingLink) {
-      setRedirectPath(toSlug(displayName));
-    }
-  }, [displayName, slugEdited, editingLink]);
+    const slug = toSlug(displayName);
+    setRedirectPath(slug);
+    
+    // Clear slug error when name changes
+    if (slugError) setSlugError('');
+  }, [displayName]);
 
   if (!isOpen) return null;
 
-  const handleRedirectPathBlur = async () => {
-    if (!redirectPath) return;
+  const validateSlug = async () => {
+    if (!redirectPath) return true;
     
     if (editingLink && editingLink.redirect_path === redirectPath) {
-      setSlugError('');
-      return;
+      return true;
     }
 
     const taken = await isRedirectPathTaken(redirectPath);
     if (taken) {
-      setSlugError('This redirect path is already taken.');
-    } else {
-      setSlugError('');
+      setSlugError('A link with this name already exists.');
+      return false;
     }
+    return true;
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -101,9 +99,12 @@ export default function LinkPanel({ isOpen, onClose, onSubmit, editingLink }: Li
       setUrlError('Please enter a valid URL (e.g., https://...)');
       return;
     }
-    if (slugError) return;
+
+    const isSlugValid = await validateSlug();
+    if (!isSlugValid) return;
+
     if (!redirectPath) {
-      setSlugError('Redirect path is required.');
+      setSlugError('A valid display name is required to generate a link.');
       return;
     }
 
@@ -180,14 +181,25 @@ export default function LinkPanel({ isOpen, onClose, onSubmit, editingLink }: Li
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
               placeholder="e.g. S26 Project Member Application"
-              className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
+              className={`px-4 py-3 bg-gray-50 border rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all ${
+                slugError ? 'border-red-400' : 'border-gray-200'
+              }`}
             />
+            {slugError && <p className="text-xs text-red-500 font-medium">{slugError}</p>}
+            
+            {/* URL Preview */}
+            {displayName && (
+              <div className="flex items-center gap-1.5 px-3 py-2 bg-blue-50 rounded-lg border border-blue-100 w-fit">
+                <span className="text-[11px] font-bold text-blue-400 uppercase tracking-tight">URL Preview:</span>
+                <span className="text-xs font-medium text-blue-700">tinycl.com/{redirectPath}</span>
+              </div>
+            )}
           </div>
 
           {/* URL */}
           <div className="flex flex-col space-y-2">
             <label className="text-xs font-bold text-gray-500 uppercase tracking-wider">
-              URL <span className="text-red-400">*</span>
+              Destination URL <span className="text-red-400">*</span>
             </label>
             <input
               required
@@ -201,34 +213,6 @@ export default function LinkPanel({ isOpen, onClose, onSubmit, editingLink }: Li
               }`}
             />
             {urlError && <p className="text-xs text-red-500 font-medium">{urlError}</p>}
-          </div>
-
-          {/* Redirect Path */}
-          <div className="flex flex-col space-y-2">
-            <label className="text-xs font-bold text-gray-500 uppercase tracking-wider">
-              Redirect Path <span className="text-red-400">*</span>
-            </label>
-            <div className={`flex items-center bg-gray-50 border rounded-xl overflow-hidden focus-within:ring-2 focus-within:ring-blue-500 transition-all ${
-              slugError ? 'border-red-400' : 'border-gray-200'
-            }`}>
-              <span className="px-3 py-3 bg-gray-100 text-gray-400 text-sm font-medium border-right border-gray-200 select-none">
-                tinycl.com/
-              </span>
-              <input
-                required
-                value={redirectPath}
-                onChange={(e) => {
-                  setRedirectPath(stripLeadingSlash(e.target.value));
-                  setSlugEdited(true);
-                  setSlugError('');
-                }}
-                onBlur={handleRedirectPathBlur}
-                placeholder="slug-here"
-                className="flex-1 px-3 py-3 bg-transparent focus:outline-none text-gray-900"
-              />
-            </div>
-            {slugError && <p className="text-xs text-red-500 font-medium">{slugError}</p>}
-            <p className="text-[11px] text-gray-400 font-medium">Must be a unique, lowercase-kebab slug.</p>
           </div>
 
           {/* Submit */}

--- a/src/components/portal/internal/tinycl/LinkPanel.tsx
+++ b/src/components/portal/internal/tinycl/LinkPanel.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { createLink, updateLink, isRedirectPathTaken, Link } from '@/lib/supabase/linksService';
+import { createClient } from '@/lib/supabase/client';
+import { IoClose } from 'react-icons/io5';
+
+interface LinkPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  editingLink?: Link;
+}
+
+// --- Helpers ---
+
+function toSlug(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+function stripLeadingSlash(value: string): string {
+  return value.startsWith('/') ? value.slice(1) : value;
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export default function LinkPanel({ isOpen, onClose, onSubmit, editingLink }: LinkPanelProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  
+  // Form state
+  const [displayName, setDisplayName] = useState('');
+  const [url, setUrl] = useState('');
+  const [redirectPath, setRedirectPath] = useState('');
+  const [slugEdited, setSlugEdited] = useState(false);
+
+  // Validation state
+  const [urlError, setUrlError] = useState('');
+  const [slugError, setSlugError] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setError(null);
+      setUrlError('');
+      setSlugError('');
+      if (editingLink) {
+        setDisplayName(editingLink.display_name);
+        setUrl(editingLink.url);
+        setRedirectPath(editingLink.redirect_path);
+        setSlugEdited(true);
+      } else {
+        setDisplayName('');
+        setUrl('');
+        setRedirectPath('');
+        setSlugEdited(false);
+      }
+    }
+  }, [isOpen, editingLink]);
+
+  useEffect(() => {
+    if (!slugEdited && !editingLink) {
+      setRedirectPath(toSlug(displayName));
+    }
+  }, [displayName, slugEdited, editingLink]);
+
+  if (!isOpen) return null;
+
+  const handleRedirectPathBlur = async () => {
+    if (!redirectPath) return;
+    
+    if (editingLink && editingLink.redirect_path === redirectPath) {
+      setSlugError('');
+      return;
+    }
+
+    const taken = await isRedirectPathTaken(redirectPath);
+    if (taken) {
+      setSlugError('This redirect path is already taken.');
+    } else {
+      setSlugError('');
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!displayName.trim()) return;
+    if (!isValidUrl(url)) {
+      setUrlError('Please enter a valid URL (e.g., https://...)');
+      return;
+    }
+    if (slugError) return;
+    if (!redirectPath) {
+      setSlugError('Redirect path is required.');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const supabase = createClient();
+      const { data: { user } } = await supabase.auth.getUser();
+
+      const payload = {
+        display_name: displayName.trim(),
+        url: url.trim(),
+        redirect_path: redirectPath,
+      };
+
+      if (editingLink) {
+        await updateLink(editingLink.id, payload);
+      } else {
+        await createLink({
+          ...payload,
+          created_by: user?.id ?? null,
+        });
+      }
+
+      onSubmit();
+      onClose();
+    } catch (err: any) {
+      console.error('Submission error:', err);
+      setError(err?.message ?? 'Failed to save link. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex">
+      {/* Backdrop */}
+      <div
+        className="flex-1 bg-black/30 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div className="w-full max-w-xl bg-white shadow-2xl flex flex-col border-l border-gray-100 h-full animate-in slide-in-from-right duration-300">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 bg-gray-50 flex-shrink-0">
+          <h2 className="text-xl font-bold text-gray-900">
+            {editingLink ? 'Edit Link' : 'New Link'}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-gray-200 transition-colors text-gray-500"
+          >
+            <IoClose size={24} />
+          </button>
+        </div>
+
+        {/* Form body */}
+        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-6 space-y-6">
+          {error && (
+            <div className="p-4 bg-red-50 text-red-700 border border-red-200 rounded-xl text-sm font-medium">
+              {error}
+            </div>
+          )}
+
+          {/* Display Name */}
+          <div className="flex flex-col space-y-2">
+            <label className="text-xs font-bold text-gray-500 uppercase tracking-wider">
+              Display Name <span className="text-red-400">*</span>
+            </label>
+            <input
+              required
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="e.g. S26 Project Member Application"
+              className="px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
+            />
+          </div>
+
+          {/* URL */}
+          <div className="flex flex-col space-y-2">
+            <label className="text-xs font-bold text-gray-500 uppercase tracking-wider">
+              URL <span className="text-red-400">*</span>
+            </label>
+            <input
+              required
+              type="url"
+              value={url}
+              onChange={(e) => { setUrl(e.target.value); setUrlError(''); }}
+              onBlur={() => { if (url && !isValidUrl(url)) setUrlError('Invalid URL'); }}
+              placeholder="https://forms.gle/abc123"
+              className={`px-4 py-3 bg-gray-50 border rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all ${
+                urlError ? 'border-red-400' : 'border-gray-200'
+              }`}
+            />
+            {urlError && <p className="text-xs text-red-500 font-medium">{urlError}</p>}
+          </div>
+
+          {/* Redirect Path */}
+          <div className="flex flex-col space-y-2">
+            <label className="text-xs font-bold text-gray-500 uppercase tracking-wider">
+              Redirect Path <span className="text-red-400">*</span>
+            </label>
+            <div className={`flex items-center bg-gray-50 border rounded-xl overflow-hidden focus-within:ring-2 focus-within:ring-blue-500 transition-all ${
+              slugError ? 'border-red-400' : 'border-gray-200'
+            }`}>
+              <span className="px-3 py-3 bg-gray-100 text-gray-400 text-sm font-medium border-right border-gray-200 select-none">
+                tinycl.com/
+              </span>
+              <input
+                required
+                value={redirectPath}
+                onChange={(e) => {
+                  setRedirectPath(stripLeadingSlash(e.target.value));
+                  setSlugEdited(true);
+                  setSlugError('');
+                }}
+                onBlur={handleRedirectPathBlur}
+                placeholder="slug-here"
+                className="flex-1 px-3 py-3 bg-transparent focus:outline-none text-gray-900"
+              />
+            </div>
+            {slugError && <p className="text-xs text-red-500 font-medium">{slugError}</p>}
+            <p className="text-[11px] text-gray-400 font-medium">Must be a unique, lowercase-kebab slug.</p>
+          </div>
+
+          {/* Submit */}
+          <div className="pt-4">
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-4 rounded-xl shadow-lg shadow-blue-100 transition-all transform hover:-translate-y-0.5 disabled:opacity-50 disabled:transform-none flex items-center justify-center"
+            >
+              {loading ? 'Saving...' : editingLink ? 'Update Link' : 'Add Link'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/supabase/linksService.ts
+++ b/src/lib/supabase/linksService.ts
@@ -7,6 +7,7 @@ export interface Link {
   redirect_path: string;
   created_by: string | null;
   created_at: string;
+  position: number | null;
 }
 
 export interface CreateLinkPayload {
@@ -14,6 +15,7 @@ export interface CreateLinkPayload {
   url: string;
   redirect_path: string;
   created_by?: string | null;
+  position?: number | null;
 }
 
 /**
@@ -24,6 +26,7 @@ export async function getLinks(): Promise<Link[]> {
   const { data, error } = await supabase
     .from('links')
     .select('*')
+    .order('position', { ascending: true, nullsFirst: true })
     .order('created_at', { ascending: false });
 
   if (error) {
@@ -50,10 +53,6 @@ export async function isRedirectPathTaken(redirectPath: string): Promise<boolean
 /**
  * Inserts a new link row.
  * NOTE: Requires an INSERT RLS policy on public.links for authenticated users.
- * Suggested policy:
- *   CREATE POLICY "Authenticated users can insert links"
- *   ON public.links FOR INSERT TO authenticated
- *   WITH CHECK (auth.uid() = created_by);
  */
 export async function createLink(payload: CreateLinkPayload): Promise<Link> {
   const supabase = createClient();
@@ -101,6 +100,29 @@ export async function deleteLink(id: string): Promise<void> {
 
   if (error) {
     console.error('Error deleting link:', error);
+    throw error;
+  }
+}
+/**
+ * Batch updates the positions of multiple links.
+ */
+export async function updateLinkPositions(updates: { id: string, position: number }[]): Promise<void> {
+  const supabase = createClient();
+  
+  // Note: For small numbers of links, individual updates are fine.
+  // For larger sets, a stored procedure (RPC) would be better.
+  const promises = updates.map(u => 
+    supabase
+      .from('links')
+      .update({ position: u.position })
+      .eq('id', u.id)
+  );
+
+  const results = await Promise.all(promises);
+  const error = results.find(r => r.error)?.error;
+
+  if (error) {
+    console.error('Error updating link positions:', error);
     throw error;
   }
 }

--- a/src/lib/supabase/linksService.ts
+++ b/src/lib/supabase/linksService.ts
@@ -17,14 +17,14 @@ export interface CreateLinkPayload {
 }
 
 /**
- * Fetches all links ordered by creation date (oldest first).
+ * Fetches all links ordered by creation date (newest first).
  */
 export async function getLinks(): Promise<Link[]> {
   const supabase = createClient();
   const { data, error } = await supabase
     .from('links')
     .select('*')
-    .order('created_at', { ascending: true });
+    .order('created_at', { ascending: false });
 
   if (error) {
     console.error('Error fetching links:', error);

--- a/src/lib/supabase/linksService.ts
+++ b/src/lib/supabase/linksService.ts
@@ -1,0 +1,106 @@
+import { createClient } from './client';
+
+export interface Link {
+  id: string;
+  display_name: string;
+  url: string;
+  redirect_path: string;
+  created_by: string | null;
+  created_at: string;
+}
+
+export interface CreateLinkPayload {
+  display_name: string;
+  url: string;
+  redirect_path: string;
+  created_by?: string | null;
+}
+
+/**
+ * Fetches all links ordered by creation date (oldest first).
+ */
+export async function getLinks(): Promise<Link[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('links')
+    .select('*')
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    console.error('Error fetching links:', error);
+    throw error;
+  }
+  return (data ?? []) as Link[];
+}
+
+/**
+ * Checks whether a redirect_path is already taken.
+ * Returns true if it is taken, false if it's free.
+ */
+export async function isRedirectPathTaken(redirectPath: string): Promise<boolean> {
+  const supabase = createClient();
+  const { data } = await supabase
+    .from('links')
+    .select('id')
+    .eq('redirect_path', redirectPath)
+    .maybeSingle();
+  return !!data;
+}
+
+/**
+ * Inserts a new link row.
+ * NOTE: Requires an INSERT RLS policy on public.links for authenticated users.
+ * Suggested policy:
+ *   CREATE POLICY "Authenticated users can insert links"
+ *   ON public.links FOR INSERT TO authenticated
+ *   WITH CHECK (auth.uid() = created_by);
+ */
+export async function createLink(payload: CreateLinkPayload): Promise<Link> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('links')
+    .insert([payload])
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error creating link:', error);
+    throw error;
+  }
+  return data as Link;
+}
+
+/**
+ * Updates an existing link.
+ */
+export async function updateLink(id: string, updates: Partial<CreateLinkPayload>): Promise<Link> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('links')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error updating link:', error);
+    throw error;
+  }
+  return data as Link;
+}
+
+/**
+ * Deletes a link by ID.
+ */
+export async function deleteLink(id: string): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from('links')
+    .delete()
+    .eq('id', id);
+
+  if (error) {
+    console.error('Error deleting link:', error);
+    throw error;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,6 +121,11 @@
   dependencies:
     "@babel/types" "^7.28.5"
 
+"@babel/runtime@^7.26.7":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@babel/template@^7.27.2":
   version "7.27.2"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz"
@@ -253,6 +258,17 @@
   dependencies:
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
+
+"@hello-pangea/dnd@^18.0.1":
+  version "18.0.1"
+  resolved "https://registry.yarnpkg.com/@hello-pangea/dnd/-/dnd-18.0.1.tgz#7d5ef7fe8bddf195307b16e03635b1be582b7b8d"
+  integrity sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==
+  dependencies:
+    "@babel/runtime" "^7.26.7"
+    css-box-model "^1.2.1"
+    raf-schd "^4.0.3"
+    react-redux "^9.2.0"
+    redux "^5.0.1"
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -804,6 +820,11 @@
   integrity sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==
   dependencies:
     csstype "^3.2.2"
+
+"@types/use-sync-external-store@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz#60be8d21baab8c305132eb9cb912ed497852aadc"
+  integrity sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==
 
 "@types/ws@^8.18.1":
   version "8.18.1"
@@ -1501,6 +1522,13 @@ cross-spawn@^7.0.6:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css-box-model@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -3360,6 +3388,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+raf-schd@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
 react-dom@latest:
   version "19.2.3"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz"
@@ -3376,6 +3409,14 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-redux@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-9.2.0.tgz#96c3ab23fb9a3af2cb4654be4b51c989e32366f5"
+  integrity sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==
+  dependencies:
+    "@types/use-sync-external-store" "^0.0.6"
+    use-sync-external-store "^1.4.0"
 
 react@latest:
   version "19.2.3"
@@ -3404,6 +3445,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+redux@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
+  integrity sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -3944,6 +3990,11 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+tiny-invariant@^1.0.6:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
 tinyglobby@^0.2.11, tinyglobby@^0.2.13, tinyglobby@^0.2.15:
   version "0.2.15"
   resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz"
@@ -4147,6 +4198,11 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-sync-external-store@^1.4.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Added components under portal > internal > tinycl for the design of the tinyCL internal page. Users can now see all past tinyCL links and edit them on the website in a similar format to how the tinyCL currently looks. Available features: edit, delete, and create new links and it will automatically be reflected on the links table in supabase through the new LinksService.ts. I will also make a pr for the changes to be updated on the tinycl site using an edgefunction/webhook. 