### PR TITLE
updating role restrictions for design and tinycl pages

### DIFF
--- a/src/app/(portal)/portal/internal/design/page.tsx
+++ b/src/app/(portal)/portal/internal/design/page.tsx
@@ -6,6 +6,7 @@ import { DesignRequest } from '@/types/designRequest';
 import DesignRequestBoard from '@/components/portal/internal/design/DesignRequestBoard';
 import RequestPanel from '@/components/portal/internal/design/RequestPanel';
 import { getCurrentQuarter, getAllQuarters } from '@/lib/utils/quarterService';
+import { useIsDesignApprover } from '@/lib/hooks/useIsDesignApprover';
 
 export default function DesignPage() {
   const [requests, setRequests] = useState<DesignRequest[]>([]);
@@ -13,6 +14,8 @@ export default function DesignPage() {
   const [editingRequest, setEditingRequest] = useState<DesignRequest | undefined>();
   const [selectedQuarter, setSelectedQuarter] = useState(getCurrentQuarter());
   const quarters = useMemo(() => getAllQuarters('2026-03-21'), []);
+  const { isApprover } = useIsDesignApprover();
+
 
   const loadRequests = async () => {
     try {
@@ -72,14 +75,16 @@ export default function DesignPage() {
       </div>
 
       {/* New Button - Below Instructions */}
-      <div className="flex justify-end">
-        <button
-          onClick={handleOpenCreate}
-          className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded-xl shadow-lg shadow-blue-200 transition-all transform hover:-translate-y-0.5 active:scale-95"
-        >
-          New +
-        </button>
-      </div>
+      {isApprover && (
+        <div className="flex justify-end">
+          <button
+            onClick={handleOpenCreate}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded-xl shadow-lg shadow-blue-200 transition-all transform hover:-translate-y-0.5 active:scale-95"
+          >
+            New +
+          </button>
+        </div>
+      )}
 
       {/* Board */}
       <DesignRequestBoard
@@ -87,6 +92,7 @@ export default function DesignPage() {
         selectedQuarter={selectedQuarter}
         onEditRequest={handleOpenEdit}
         onRefresh={loadRequests}
+        isApprover={isApprover}
       />
 
       <RequestPanel

--- a/src/app/(portal)/portal/internal/tinycl/page.tsx
+++ b/src/app/(portal)/portal/internal/tinycl/page.tsx
@@ -4,12 +4,15 @@ import { useState, useEffect } from 'react';
 import { getLinks, deleteLink, updateLinkPositions, Link } from '@/lib/supabase/linksService';
 import LinkBoard from '@/components/portal/internal/tinycl/LinkBoard';
 import LinkPanel from '@/components/portal/internal/tinycl/LinkPanel';
+import { useIsTinyCLApprover } from '@/lib/hooks/useIsTinyCLApprover';
 
 export default function TinyCLPage() {
   const [links, setLinks] = useState<Link[]>([]);
   const [loading, setLoading] = useState(true);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const [editingLink, setEditingLink] = useState<Link | undefined>();
+  const { isApprover } = useIsTinyCLApprover();
+
 
   const loadLinks = async () => {
     try {
@@ -75,12 +78,14 @@ export default function TinyCLPage() {
       {/* Header row — matches Design/Projects page */}
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-gray-900">TinyCL</h1>
-        <button
-          onClick={handleAddNew}
-          className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded-xl shadow-lg shadow-blue-200 transition-all transform hover:-translate-y-0.5 active:scale-95"
-        >
-          New +
-        </button>
+        {isApprover && (
+          <button
+            onClick={handleAddNew}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-6 rounded-xl shadow-lg shadow-blue-200 transition-all transform hover:-translate-y-0.5 active:scale-95"
+          >
+            New +
+          </button>
+        )}
       </div>
 
 
@@ -90,8 +95,8 @@ export default function TinyCLPage() {
         loading={loading}
         onEditLink={handleEditLink}
         onDeleteLink={handleDeleteLink}
-        onAddNew={handleAddNew}
         onOrderChange={handleOrderChange}
+        isApprover={isApprover}
       />
 
       {/* Slide-over panel for Create/Update actions */}

--- a/src/components/portal/internal/design/DesignRequestBoard.tsx
+++ b/src/components/portal/internal/design/DesignRequestBoard.tsx
@@ -28,9 +28,10 @@ interface DesignRequestBoardProps {
   selectedQuarter: string;
   onEditRequest: (request: DesignRequest) => void;
   onRefresh: () => void;
+  isApprover: boolean;
 }
 
-export default function DesignRequestBoard({ requests, selectedQuarter, onEditRequest, onRefresh }: DesignRequestBoardProps) {
+export default function DesignRequestBoard({ requests, selectedQuarter, onEditRequest, onRefresh, isApprover }: DesignRequestBoardProps) {
   const filteredRequests = useMemo(
     () => requests.filter(r => r.quarter === selectedQuarter),
     [requests, selectedQuarter]
@@ -77,6 +78,7 @@ export default function DesignRequestBoard({ requests, selectedQuarter, onEditRe
                 request={request}
                 onEdit={() => onEditRequest(request)}
                 onRefresh={onRefresh}
+                isApprover={isApprover}
               />
             ))}
             {grouped[urgency].length === 0 && (

--- a/src/components/portal/internal/design/DesignRequestCard.tsx
+++ b/src/components/portal/internal/design/DesignRequestCard.tsx
@@ -42,9 +42,10 @@ interface DesignRequestCardProps {
   request: DesignRequest;
   onEdit: () => void;
   onRefresh: () => void;
+  isApprover: boolean;
 }
 
-export default function DesignRequestCard({ request, onEdit, onRefresh }: DesignRequestCardProps) {
+export default function DesignRequestCard({ request, onEdit, onRefresh, isApprover }: DesignRequestCardProps) {
   const [isUpdating, setIsUpdating] = useState(false);
   const [creatorProfile, setCreatorProfile] = useState<{ name: string; id: string } | null>(null);
 
@@ -93,12 +94,14 @@ export default function DesignRequestCard({ request, onEdit, onRefresh }: Design
   return (
     <div className="bg-white p-4 rounded-2xl shadow-sm border border-[#D4D7E5]/50 space-y-3 hover:shadow-md transition-shadow relative group">
       {/* Three-dot edit menu */}
-      <button
-        onClick={onEdit}
-        className="absolute top-3 right-3 p-1 rounded-lg hover:bg-gray-100 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity"
-      >
-        <BsThreeDots size={16} />
-      </button>
+      {isApprover && (
+        <button
+          onClick={onEdit}
+          className="absolute top-3 right-3 p-1 rounded-lg hover:bg-gray-100 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <BsThreeDots size={16} />
+        </button>
+      )}
 
       {/* Name / Title */}
       <div className="font-bold text-gray-800 leading-tight pr-6 text-[15px]">
@@ -139,21 +142,30 @@ export default function DesignRequestCard({ request, onEdit, onRefresh }: Design
       </div>
 
       {/* Status tabs */}
-      <div className={`flex p-0.5 bg-gray-100/80 rounded-xl mt-2 ${isUpdating ? 'opacity-50 pointer-events-none' : ''}`}>
-        {(Object.keys(STATUS_LABELS) as DesignRequestStatus[]).map((status) => (
-          <button
-            key={status}
-            onClick={() => handleStatusChange(status)}
-            className={`flex-1 text-[10px] font-bold py-1.5 px-1 rounded-lg transition-all ${
-              request.status === status
-                ? STATUS_ACTIVE_CLASS[status]
-                : 'text-gray-400 hover:text-gray-500'
-            }`}
-          >
-            {STATUS_LABELS[status]}
-          </button>
-        ))}
-      </div>
+      {isApprover ? (
+        <div className={`flex p-0.5 bg-gray-100/80 rounded-xl mt-2 ${isUpdating ? 'opacity-50 pointer-events-none' : ''}`}>
+          {(Object.keys(STATUS_LABELS) as DesignRequestStatus[]).map((status) => (
+            <button
+              key={status}
+              onClick={() => handleStatusChange(status)}
+              className={`flex-1 text-[10px] font-bold py-1.5 px-1 rounded-lg transition-all ${
+                request.status === status
+                  ? STATUS_ACTIVE_CLASS[status]
+                  : 'text-gray-400 hover:text-gray-500'
+              }`}
+            >
+              {STATUS_LABELS[status]}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="flex pt-1">
+          <span className="text-[10px] font-bold bg-gray-100 text-gray-600 px-2 py-1 rounded-md">
+            {STATUS_LABELS[request.status]}
+          </span>
+        </div>
+      )}
     </div>
   );
 }
+

--- a/src/components/portal/internal/tinycl/LinkBoard.tsx
+++ b/src/components/portal/internal/tinycl/LinkBoard.tsx
@@ -9,8 +9,8 @@ interface LinkBoardProps {
   loading: boolean;
   onEditLink: (link: Link) => void;
   onDeleteLink: (id: string) => void;
-  onAddNew: () => void;
   onOrderChange: (newLinks: Link[]) => void;
+  isApprover: boolean;
 }
 
 export default function LinkBoard({ 
@@ -18,7 +18,8 @@ export default function LinkBoard({
   loading, 
   onEditLink, 
   onDeleteLink, 
-  onOrderChange
+  onOrderChange,
+  isApprover
 }: LinkBoardProps) {
 
   const handleDragEnd = (result: DropResult) => {
@@ -53,7 +54,12 @@ export default function LinkBoard({
                 className="flex flex-col gap-3"
               >
                 {links.map((link, index) => (
-                  <Draggable key={link.id} draggableId={link.id} index={index}>
+                  <Draggable 
+                    key={link.id} 
+                    draggableId={link.id} 
+                    index={index}
+                    isDragDisabled={!isApprover}
+                  >
                     {(provided, snapshot) => (
                       <div
                         ref={provided.innerRef}
@@ -68,6 +74,7 @@ export default function LinkBoard({
                           onEdit={onEditLink}
                           onDelete={onDeleteLink}
                           dragHandleProps={provided.dragHandleProps}
+                          isApprover={isApprover}
                         />
                       </div>
                     )}

--- a/src/components/portal/internal/tinycl/LinkCard.tsx
+++ b/src/components/portal/internal/tinycl/LinkCard.tsx
@@ -9,9 +9,10 @@ interface LinkCardProps {
   onEdit: (link: Link) => void;
   onDelete: (id: string) => void;
   dragHandleProps?: any;
+  isApprover: boolean;
 }
 
-export default function LinkCard({ link, onEdit, onDelete, dragHandleProps }: LinkCardProps) {
+export default function LinkCard({ link, onEdit, onDelete, dragHandleProps, isApprover }: LinkCardProps) {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -28,12 +29,14 @@ export default function LinkCard({ link, onEdit, onDelete, dragHandleProps }: Li
   return (
     <div className="relative w-full group flex items-center gap-2">
       {/* Drag Handle */}
-      <div 
-        {...dragHandleProps}
-        className="p-2 text-gray-300 hover:text-gray-500 cursor-grab active:cursor-grabbing transition-colors"
-      >
-        <RxDragHandleDots2 size={24} />
-      </div>
+      {isApprover && (
+        <div 
+          {...dragHandleProps}
+          className="p-2 text-gray-300 hover:text-gray-500 cursor-grab active:cursor-grabbing transition-colors"
+        >
+          <RxDragHandleDots2 size={24} />
+        </div>
+      )}
 
       <div className="relative flex-1">
         <a
@@ -45,43 +48,45 @@ export default function LinkCard({ link, onEdit, onDelete, dragHandleProps }: Li
           {link.display_name}
         </a>
         
-        <div className="absolute right-3 top-1/2 -translate-y-1/2 z-10" ref={menuRef}>
-          <button 
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setShowMenu(!showMenu);
-            }}
-            className="p-2 bg-transparent border-none cursor-pointer text-[#9ca3af] rounded-full flex items-center justify-center transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none"
-          >
-            <RxDotsVertical size={20} />
-          </button>
+        {isApprover && (
+          <div className="absolute right-3 top-1/2 -translate-y-1/2 z-10" ref={menuRef}>
+            <button 
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setShowMenu(!showMenu);
+              }}
+              className="p-2 bg-transparent border-none cursor-pointer text-[#9ca3af] rounded-full flex items-center justify-center transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none"
+            >
+              <RxDotsVertical size={20} />
+            </button>
 
-          {showMenu && (
-            <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-xl z-[100] min-w-[120px] py-1 overflow-hidden animate-in fade-in zoom-in duration-100">
-              <button 
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onEdit(link);
-                  setShowMenu(false);
-                }}
-                className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-gray-700 cursor-pointer hover:bg-gray-50 transition-colors"
-              >
-                Edit
-              </button>
-              <button 
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDelete(link.id);
-                  setShowMenu(false);
-                }}
-                className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-red-600 cursor-pointer hover:bg-red-50 transition-colors"
-              >
-                Delete
-              </button>
-            </div>
-          )}
-        </div>
+            {showMenu && (
+              <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-xl z-[100] min-w-[120px] py-1 overflow-hidden animate-in fade-in zoom-in duration-100">
+                <button 
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEdit(link);
+                    setShowMenu(false);
+                  }}
+                  className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-gray-700 cursor-pointer hover:bg-gray-50 transition-colors"
+                >
+                  Edit
+                </button>
+                <button 
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(link.id);
+                    setShowMenu(false);
+                  }}
+                  className="w-full px-4 py-2 text-left bg-none border-none text-sm font-medium text-red-600 cursor-pointer hover:bg-red-50 transition-colors"
+                >
+                  Delete
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/lib/hooks/useIsDesignApprover.ts
+++ b/src/lib/hooks/useIsDesignApprover.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabase/client';
+
+const APPROVER_ROLES = ['director', 'president', 'board - design'];
+
+/**
+ * Returns true when the current user has an internal role allowed to
+ * approve / manage design requests.
+ */
+export function useIsDesignApprover() {
+  const [isApprover, setIsApprover] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function check() {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        if (!cancelled) {
+          setIsApprover(false);
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      const { data } = await supabase
+        .from('user_context_roles')
+        .select('context, roles!inner(name)')
+        .eq('user_id', user.id);
+
+      const allowed = (data || []).some((row) => {
+        if (row.context !== 'internal') return false;
+        const name = (row.roles as unknown as { name: string })?.name;
+        return APPROVER_ROLES.includes(name);
+      });
+
+      if (!cancelled) {
+        setIsApprover(allowed);
+        setIsLoading(false);
+      }
+    }
+
+    check();
+    return () => { cancelled = true; };
+  }, []);
+
+  return { isApprover, isLoading };
+}

--- a/src/lib/hooks/useIsTinyCLApprover.ts
+++ b/src/lib/hooks/useIsTinyCLApprover.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabase/client';
+
+const APPROVER_ROLES = ['director', 'president'];
+
+/**
+ * Returns true when the current user has an internal role allowed to
+ * manage TinyCL links.
+ */
+export function useIsTinyCLApprover() {
+  const [isApprover, setIsApprover] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function check() {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        if (!cancelled) {
+          setIsApprover(false);
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      const { data } = await supabase
+        .from('user_context_roles')
+        .select('context, roles!inner(name)')
+        .eq('user_id', user.id);
+
+      const allowed = (data || []).some((row) => {
+        if (row.context !== 'internal') return false;
+        const name = (row.roles as unknown as { name: string })?.name;
+        return APPROVER_ROLES.includes(name);
+      });
+
+      if (!cancelled) {
+        setIsApprover(allowed);
+        setIsLoading(false);
+      }
+    }
+
+    check();
+    return () => { cancelled = true; };
+  }, []);
+
+  return { isApprover, isLoading };
+}


### PR DESCRIPTION
Created new permissions hooks: 
- useIsDesignApprover.ts - allowed approvers are director, president, and board - design.
- useIsTinyCLApprover.ts - allowed approvers are director and president.

The "New +" button, the "..." edit menu, and the Status Toggle tabs are now only visible/usable by Design Approvers. The "New +" button, Edit/Delete menus, and Drag-and-Drop reordering are now restricted to TinyCL Approvers.
